### PR TITLE
#Fix - Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ app.use(session({ secret: 'keyboard cat', cookie: { maxAge: 60000 }}))
 app.use(function(req, res, next){
   var sess = req.session;
   if (sess.views) {
+    sess.views++;
     res.setHeader('Content-Type', 'text/html');
     res.write('<p>views: ' + sess.views + '</p>');
     res.write('<p>expires in: ' + (sess.cookie.maxAge / 1000) + 's</p>');
     res.end();
-    sess.views++;
   } else {
     sess.views = 1;
     res.end('welcome to the session demo. refresh!');


### PR DESCRIPTION
Manipulation of session variables must be before res.end() or it will take no effect. 
Tested with express 4.0.0, session using connect-redis, but with cookies it should have the same issue.
