### PR TITLE
Fix parsing logic around resave option

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function session(options){
     , rollingSessions = options.rolling || false;
 
   // TODO: switch default to false on next major
-  var resaveSession = options.resave === undefined
+  var resaveSession = (options.resave === undefined || options.resave)
     ? true
     : false;
 

--- a/test/session.js
+++ b/test/session.js
@@ -114,6 +114,35 @@ describe('session()', function(){
   })
 
   describe('resave option', function(){
+    it('should allow setting to true', function(done){
+      var count = 0;
+      var app = express();
+      app.use(cookieParser());
+      app.use(session({ resave: true, secret: 'keyboard cat', cookie: { maxAge: min }}));
+      app.use(function(req, res, next){
+        var save = req.session.save;
+        res.setHeader('x-count', count);
+        req.session.user = 'bob';
+        req.session.save = function(fn){
+          res.setHeader('x-count', ++count);
+          return save.call(this, fn);
+        };
+        res.end();
+      });
+
+      request(app)
+      .get('/')
+      .expect('x-count', '1')
+      .expect(200, function(err, res){
+        if (err) return done(err);
+        request(app)
+        .get('/')
+        .set('Cookie', 'connect.sid=' + sid(res))
+        .expect('x-count', '2')
+        .expect(200, done);
+      });
+    });
+
     it('should default to true', function(done){
       var count = 0;
       var app = express();


### PR DESCRIPTION
Just noticed a bug involving the `resave` option, where if you explicitly specified `{resave: true, ... }` the option was set to false.  See the test for an example
