### PR TITLE
Only set cookie and save new sessions if modified

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Add generate option to control saving empty sessions
+
 1.3.1 / 2014-06-14
 ==================
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ middleware _before_ `session()`.
   - `rolling` - forces a cookie set on every response. This resets the expiration date. (default: `false`)
   - `resave` - forces session to be saved even when unmodified. (default: `true`)
   - `proxy` - trust the reverse proxy when setting secure cookies (via "x-forwarded-proto" header). When set to `true`, the "x-forwarded-proto" header will be used. When set to `false`, all headers are ignored. When left unset, will use the "trust proxy" setting from express. (default: `undefined`)
+  - `generate` - forces creation of session even when empty. (default: `true`)
 
 
 #### Cookie options
@@ -75,6 +76,10 @@ app.use(session(sess))
 By default `cookie.maxAge` is `null`, meaning no "expires" parameter is set
 so the cookie becomes a browser-session cookie. When the user closes the
 browser the cookie (and session) will be removed.
+
+#### Generate option
+
+If `generate: false` is specified, and the `req.session` object is not modified, nothing will be saved to your store and no `Set-Cookie` header will be sent.  This can be useful for implementing login sessions, or complying with EU cookie laws
 
 ### req.session
 


### PR DESCRIPTION
The `{ generate:  ... }` option –currently defaults to true– specifies whether the session should always be created, or only created if the session is not empty.

This generically allows the concept of a _login session_ by only setting a cookie and persisting the session when the session is modified after the express-session middleware.

There's a lot going on between the issues senchalabs/connect#451 and senchalabs/connect#899 senchalabs/connect#822.  Some of the commits around these issues allowed passing in a function that controls when the session is created.  I didn't go that route because it seems better to attach the session instance to the request object and check if its been modified after `req.end()`.  Let me know if I missed something.

Fixes #8
