### PR TITLE
fix absent of req.originalUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function session(options){
     if (!storeReady) return debug('store is disconnected'), next();
 
     // pathname mismatch
-    var originalPath = parse(req.originalUrl).pathname;
+    var originalPath = parse(req.originalUrl || req.url).pathname;
     if (0 != originalPath.indexOf(cookie.path || '/')) return next();
 
     // backwards compatibility for signed cookies


### PR DESCRIPTION
Middleware fails when req.originalUrl is not present.

Here is related discussion https://github.com/expressjs/serve-static/issues/3
