### PR TITLE
added DO_NOT_SAVE flag onto the request, so we can keep req.session intact

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,9 +263,13 @@ function session(options){
 
     // determine if session should be saved to store
     function shouldSave(req) {
-      return cookieId != req.sessionID
-        ? saveUninitializedSession || isModified(req.session)
-        : resaveSession || isModified(req.session);
+      if(req.DO_NOT_SAVE === true) {
+        return false;
+      else {
+        return cookieId != req.sessionID
+          ? saveUninitializedSession || isModified(req.session)
+          : resaveSession || isModified(req.session);
+      }
     }
 
     // determine if cookie should be set on response


### PR DESCRIPTION
Hello, 

in my application I am using sockets with session based authentification. Therefore the initial handshake request is saved and the session is available via session middleware. The problem occured, if a user logged in during a socket session. Durring the session everything works fine, but at the end, res.end() is called. Because of the login the userData in req.session is still the old one and the session would be resaved with the old user (which is not logged in anymore). I cannot simply NULL or UNDEFINE req.session, because I need the reload-function to retrieve the latest user from the session. 

So I had to implement a simple flag, which basically says DO_NOT_SAVE the session of THIS request. Now everything works fine and I wanted to propose that small change to this community.

Kind Regards
