### PR TITLE
Solve issue with redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,9 @@ function session(options){
           end.call(res);
         });
 
-        sync = false;
+        if (res.statusCode == 301 || res.statusCode == 302) {
+          sync = false;
+        }
 
         if (sync) {
           ret = res.write(chunk, encoding);


### PR DESCRIPTION
When changing the session and then calling `res.redirect(...)`
express-session calls `res.write`, which flushes the headers and causes
the browser to start redirecting without waiting for the store to finish
saving.

express-session should not send the headers until the store finishes
saving.

I patched it for now with a hack. It probably requires a more robust
solution.
