### PR TITLE
fixed head requests throwing errors for express 3.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ function session(options){
       var ret;
       var sync = true;
 
-      if (chunk === undefined) {
+      if (chunk === undefined || chunk === null) {
         chunk = '';
       }
 

--- a/test/session.js
+++ b/test/session.js
@@ -184,6 +184,34 @@ describe('session()', function(){
     .expect(200, 'Hello, world!', done);
   })
 
+  it('should handle HEAD requests which respond with undefined bodies', function (done) {
+    var app = express()
+
+    app.use(createSession())
+    app.use(function (req, res) {
+      res.setHeader('Content-Length', 1)
+      res.end(undefined, 'utf8')
+    })
+
+    request(app)
+    .head('/')
+    .expect(200, '', done)
+  })
+
+  it('should handle HEAD requests which respond with null bodies', function (done) {
+    var app = express()
+
+    app.use(createSession())
+    app.use(function (req, res) {
+      res.setHeader('Content-Length', 1)
+      res.end(null, 'utf8')
+    })
+
+    request(app)
+    .head('/')
+    .expect(200, '', done)
+  })
+
   describe('when response ended', function () {
     it('should have saved session', function (done) {
       var saved = false


### PR DESCRIPTION
In express 3.x, any HEAD request that uses express-session will throw a 500 error.

This is because `express/lib/response.js` calls `this.end(null, encoding)` if the request is a HEAD request ([see closest blame here](https://github.com/strongloop/express/commit/f14e39d4515c81c1e5c980b7ce31566eeeb84734#diff-d86a59ede7d999db4b7bc43cb25a1c11L155)).

As the HEAD request just gets the headers for a particular resource, then the content length can also be set. This unfortunately means that the `res.end` patch attempts to create a `new Buffer(null)` which throws (usually when `node/lib/buffer.js` getting the length property of null).

This PR fixes it, with an extra test for `res.end(undefined)` just to be sure.
