### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ a string that will be used as a session ID. The function is given `req` as the
 first argument if you want to use some value attached to `req` when generating
 the ID.
 
-The default valuses uses the `uid2` library to generate IDs.
+The default value is a function which uses the `uid2` library to generate IDs.
 
 **NOTE** be careful you generate unique IDs so your sessions do not conflict.
 


### PR DESCRIPTION
spell fix: "valuses" => "values" and some words to make meaning clear