### PR TITLE
Add support for secret deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var session = require('express-session')
 Create a session middleware with the given `options`.
 
 **Note** Session data is _not_ saved in the cookie itself, just the session ID.
-Session hdata is stored server-side.
+Session data is stored server-side.
 
 **Warning** The default server-side session storage, `MemoryStore`, is _purposely_
 not designed for a production environment. It will leak memory under most
@@ -104,7 +104,7 @@ How do I know if this is necessary for my store? The best way to know is to
 check with your store if it implements the `touch` method. If it does, then
 you can safely set `resave: false`. If it does not implement the `touch`
 method and your store sets an expiration date on stored sessions, then you
-likely need `resave: true`.h
+likely need `resave: true`.
 
 ##### rolling
 
@@ -132,9 +132,12 @@ it to be saved.
 
 ##### secret
 
-**Required option**
+**Required option**. This is the secret used to sign/unsign the session ID cookie:
 
-This is the secret used to sign the session ID cookie.
+ - If a string is provided, it will be used both for signing and unsigning.
+ - If an array is provided, only the first element will be used to sign the session ID cookie,
+ while all the elements will be used to unsign it. This allows to deprecate a secret used in production
+ without invalidating all sessions.
 
 ##### store
 

--- a/index.js
+++ b/index.js
@@ -608,7 +608,7 @@ function setcookie(res, name, val, secret, options) {
  */
 function signcookie(val, secret) {
   // array of secrets
-  if (Array.isArray(secret) && array.length > 0) {
+  if (Array.isArray(secret) && secret.length > 0) {
     return signature.sign(val, secret[0]);
   // single secret
   } else if ('string' === typeof secret) {

--- a/test/session.js
+++ b/test/session.js
@@ -2029,7 +2029,6 @@ function shouldSetCookieToValue(name, val) {
     var header = cookie(res);
     assert.ok(header, 'should have a cookie header')
     assert.equal(header.split('=')[0], name, 'should set cookie ' + name)
-    console.log('actual:' + header.split('=')[1].split(';')[0]);
     assert.equal(header.split('=')[1].split(';')[0], val, 'should set cookie ' + name + ' to ' + val)
   }
 }

--- a/test/session.js
+++ b/test/session.js
@@ -1127,7 +1127,7 @@ describe('session()', function(){
     })
   });
 
-  describe.only('secret option', function () {
+  describe('secret option', function () {
     it('should handle arrays', function(done){
       var app = express();
       app.use(session({ secret: ['keyboard cat', 'nyan cat'] }));


### PR DESCRIPTION
As discussed in #127, this PR allows the deprecation of a secret:
- The `secret`  value in the config object will accept an array.
- The array lists all valid secrets to check against when unsigning a cookie. 
- Only the first element of the array is used to sign new cookies.

Tests are present (not sure this is the best way to do but they work). I still need to update the README but I wanted to get that through you beforehand.

What do you think?