### PR TITLE
Don't modify options.secret; copy it to local var

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ function session(options){
     , name = options.name || options.key || 'connect.sid'
     , store = options.store || new MemoryStore
     , cookie = options.cookie || {}
+    , secret = options.secret
     , trustProxy = options.proxy
     , storeReady = true
     , rollingSessions = options.rolling || false;
@@ -116,17 +117,17 @@ function session(options){
   // TODO: switch to "destroy" on next major
   var unsetDestroy = options.unset === 'destroy';
 
-  if (Array.isArray(options.secret) && options.secret.length === 0) {
+  if (Array.isArray(secret) && secret.length === 0) {
     throw new TypeError('secret option array must contain one or more strings');
   }
 
-  if (options.secret && !Array.isArray(options.secret)) {
-    options.secret = [options.secret];
+  if (secret && !Array.isArray(secret)) {
+    secret = [secret];
   }
 
-  if (!options.secret) {
+  if (!secret) {
     deprecate('req.secret; provide secret option');
-    options.secret = undefined;
+    secret = undefined;
   }
 
   // notify user that this store is not
@@ -159,14 +160,14 @@ function session(options){
     if (0 != originalPath.indexOf(cookie.path || '/')) return next();
 
     // ensure a secret is available or bail
-    if (!options.secret && !req.secret) {
+    if (!secret && !req.secret) {
       next(new Error('secret option required for sessions'));
       return;
     }
 
     // backwards compatibility for signed cookies
     // req.secret is passed from the cookie parser middleware
-    var secrets = options.secret || [req.secret];
+    var secrets = secret || [req.secret];
 
     var originalHash;
     var originalId;


### PR DESCRIPTION
The options object that is passed in - shouldn't be modified. If the caller is using that options object elsewhere, then we'll break their code. This change broke [Let's Chat](https://sdelements.github.io/lets-chat) today.

I have updated the code so that options.secret is copied to a local variable.