### PR TITLE
Fix Grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The default value is `false`.
 Forces a session that is "uninitialized" to be saved to the store. A session is
 uninitialized when it is new but not modified. Choosing `false` is useful for
 implementing login sessions, reducing server storage usage, or complying with
-laws that require permission before setting a cookie. Choose `false` will also
+laws that require permission before setting a cookie. Choosing `false` will also
 help with race conditions where a client makes multiple parallel requests
 without a session.
 


### PR DESCRIPTION
In the _saveUnitialized_ section:

"Choose `false` will also help with race conditions where a client makes multiple parallel requests without a session."

has been changed to 

"Choosing `false` will also help with race conditions where a client makes multiple parallel requests without a session."