### PR TITLE
Condition "req.session.cookie.expires != null" is not necessary.

### DIFF
--- a/index.js
+++ b/index.js
@@ -386,9 +386,7 @@ function session(options){
         return true;
       }
 
-      return cookieId != req.sessionID
-        ? saveUninitializedSession || isModified(req.session)
-        : req.session.cookie.expires != null && isModified(req.session);
+      return (cookieId != req.sessionID && saveUninitializedSession) || isModified(req.session);
     }
 
     // generate a session if the browser doesn't send a sessionID


### PR DESCRIPTION
Because when "req.session.cookie.expires === null",
cookie don't re-set if you modified cookie.

For example,

1. First
 req.session.cookie.expires === "2015-05-23T14:26:04Z";
 req.session.cookie.path    === "/";

 → Set cookie.

2. Change to
 req.session.cookie.expires === null;
 req.session.cookie.path    === "/admin";

 → Session modified. But don't re-set cookie.

----

Tests is passed.