### PR TITLE
Save session before the `location` header is sent to the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ Force a cookie to be set on every response. This resets the expiration date.
 
 The default value is `false`.
 
+##### saveBeforeRedirect
+
+Tells the module to completly buffer the response when `location` header is set.
+This is because the browser is performing redirection immediately after the `location`
+header is parsed without waiting for the store to finish saving.
+
+The default value is `false`.
+
 ##### saveUninitialized
 
 Forces a session that is "uninitialized" to be saved to the store. A session is

--- a/index.js
+++ b/index.js
@@ -218,6 +218,8 @@ function session(options){
           return _writeHead.call(res, statusCode, reason, obj);
         }
         
+        this.statusCode = statusCode;
+        
         if ('string' != typeof(reason)) {
           obj = reason;
           reason = undefined;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@
  * @private
  */
 
-var util = require('util');
 var cookie = require('cookie');
 var crc = require('crc').crc32;
 var debug = require('debug')('express-session');
@@ -213,13 +212,13 @@ function session(options){
       res.writeHead = function writeHead(statusCode, reason, obj) {
         if (headWritten) return;
         headWritten = true;
-        
+
         // search for location header only for 3xx status codes
-        if (statusCode < 300 && statusCode >= 400) {
+        if (statusCode < 300 || statusCode >= 400) {
           return _writeHead.call(res, statusCode, reason, obj);
         }
         
-        if (!util.isString(reason)) {
+        if ('string' != typeof(reason)) {
           obj = reason;
           reason = undefined;
         }


### PR DESCRIPTION
This PR fixes the problem described in https://github.com/expressjs/session/pull/69. When user calls `res.redirect()`, it checks whether the session needs to be saved (or touched) before the `location` header is sent do the browser.

This fix doesn't work for situation when user sets the `location` header manually.

Test included.
