### PR TITLE
Manually set sessionID

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ app.use(session({
 }))
 ```
 
+##### sessionid
+
+Function to manually set the sessionID. This is most helpful for environments where
+cookies are not possible. When the expression returns no value, the regular sessionID
+will be used or generated.
+
+**NOTE** be careful with unsecured connections. When you don't use SSL, a man in the
+middle could intercept a sessionID and pick up a session from there.
+
+```js
+app.use(session({
+  sessionid: function(req) {
+    return req.query.sessionID;
+  },
+  secret: 'keyboard cat'
+}))
+```
+
 ##### name
 
 The name of the session ID cookie to set in the response (and read from in the

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ var defer = typeof setImmediate === 'function'
  * @param {Boolean} [options.resave] Resave unmodified sessions back to the store
  * @param {Boolean} [options.rolling] Enable/disable rolling session expiration
  * @param {Boolean} [options.saveUninitialized] Save uninitialized sessions to the store
- * @param {Function} [options.sessionID] Manually set session ID
+ * @param {Function} [options.sessionid] Manually set session ID
  * @param {String|Array} [options.secret] Secret for signing session ID
  * @param {Object} [options.store=MemoryStore] Session store
  * @param {String} [options.unset]
@@ -97,7 +97,7 @@ function session(options){
 
   var generateId = options.genid || generateSessionId;
 
-  var getManualSessionId = options.sessionID || function(req) {};
+  var getManualSessionId = options.sessionid || function(req) {};
 
   if (typeof generateId !== 'function') {
     throw new TypeError('genid option must be a function');

--- a/index.js
+++ b/index.js
@@ -95,8 +95,9 @@ function session(options){
   var saveUninitializedSession = options.saveUninitialized;
   var secret = options.secret;
 
-  var getManualSessionId = options.sessionID;
-  var generateId = options.genid || getManualSessionId || generateSessionId;
+  var generateId = options.genid || generateSessionId;
+
+  var getManualSessionId = options.sessionID || function(req) {};
 
   if (typeof generateId !== 'function') {
     throw new TypeError('genid option must be a function');
@@ -139,7 +140,7 @@ function session(options){
 
   // generates the new session
   store.generate = function(req){
-    req.sessionID = generateId(req);
+    req.sessionID = getManualSessionId(req) ? getManualSessionId(req) : generateId(req);
     req.session = new Session(req);
     req.session.cookie = new Cookie(cookie);
   };
@@ -178,7 +179,7 @@ function session(options){
     req.sessionStore = store;
 
     // get the session ID from the cookie
-    var cookieId = req.sessionID = getManualSessionId ? getManualSessionId(req) : getcookie(req, name, secrets);
+    var cookieId = req.sessionID = getManualSessionId(req) ? getManualSessionId(req) : getcookie(req, name, secrets);
 
     // set-cookie
     onHeaders(res, function(){

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ var defer = typeof setImmediate === 'function'
  * @param {Boolean} [options.resave] Resave unmodified sessions back to the store
  * @param {Boolean} [options.rolling] Enable/disable rolling session expiration
  * @param {Boolean} [options.saveUninitialized] Save uninitialized sessions to the store
+ * @param {Function} [options.sessionID] Manually set session ID
  * @param {String|Array} [options.secret] Secret for signing session ID
  * @param {Object} [options.store=MemoryStore] Session store
  * @param {String} [options.unset]
@@ -94,7 +95,8 @@ function session(options){
   var saveUninitializedSession = options.saveUninitialized;
   var secret = options.secret;
 
-  var generateId = options.genid || generateSessionId;
+  var getManualSessionId = options.sessionID;
+  var generateId = options.genid || getManualSessionId || generateSessionId;
 
   if (typeof generateId !== 'function') {
     throw new TypeError('genid option must be a function');
@@ -176,7 +178,7 @@ function session(options){
     req.sessionStore = store;
 
     // get the session ID from the cookie
-    var cookieId = req.sessionID = getcookie(req, name, secrets);
+    var cookieId = req.sessionID = getManualSessionId ? getManualSessionId(req) : getcookie(req, name, secrets);
 
     // set-cookie
     onHeaders(res, function(){


### PR DESCRIPTION
This will fix #158 by making it possible to manually set the `sessionID`. This is most helpful in environments where cookies are unavailable or unreliable. Tests are missing at the moment, but I can do that after someone gives this a sanity-check (because I'm not very experienced in express-middlewares).

``` js
var express = require('express');
var session = require('express-session');
var app = express();

app
  .use(session({
    secret: 'secret',
    httpOnly: false,
    resave: false,
    saveUninitialized: true,
    sessionid: function(req) {
      return req.query.sessionID;
    }
  }))
  .get('/session', function(req, res) {
    req.session.count = req.session.count + 1 || 0;
    req.session.save();
    res.send('count: ' + req.session.count);
  })
  .listen(3000, function() {
    console.log('Listening...');
  });
```
