### PR TITLE
Api sessions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-unreleased
-==========
+1.11.3 / 2015-05-22
+===================
 
   * deps: cookie@0.1.3
     - Slight optimizations

--- a/driver/cookie.js
+++ b/driver/cookie.js
@@ -1,0 +1,463 @@
+var parseUrl = require('parseurl');
+var cookie = require('cookie');
+var onHeaders = require('on-headers');
+var debug = require('debug')('express-session');
+var crc = require('crc').crc32;
+var signature = require('cookie-signature');
+var deprecate = require('depd')('express-session');
+
+/* istanbul ignore next */
+var defer = typeof setImmediate === 'function'
+  ? setImmediate
+  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
+
+module.exports = function(store, options) {
+
+  return function(req, res, next) {
+    // self-awareness
+    if (req.session) return next();
+    
+    // Handle connection as if there is no session if
+    // the store has temporarily disconnected etc
+    if (!options.storeReady) return debug('store is disconnected'), next();
+    
+    // pathname mismatch
+    var originalPath = parseUrl.original(req).pathname;
+    if (0 != originalPath.indexOf(options.cookie.path || '/')) return next();
+    
+    // ensure a secret is available or bail
+    if (!options.secret && !req.secret) {
+      next(new Error('secret option required for sessions'));
+      return;
+    }
+    
+    // backwards compatibility for signed cookies
+    // req.secret is passed from the cookie parser middleware
+    var secrets = options.secret || [req.secret];
+    
+    var originalHash;
+    var originalId;
+    var savedHash;
+    
+    // expose store
+    req.sessionStore = store;
+    
+    // get the session ID from the cookie
+    var cookieId = req.sessionID = getcookie(req, options.name, secrets);
+    
+    // set-cookie
+    onHeaders(res, function(){
+      if (!req.session) {
+        debug('no session');
+        return;
+      }
+    
+      var cookie = req.session.cookie;
+    
+      // only send secure cookies via https
+      if (cookie.secure && !issecure(req, options.trustProxy)) {
+        debug('not secured');
+        return;
+      }
+    
+      if (!shouldSetCookie(req)) {
+        return;
+      }
+    
+      setcookie(res, options.name, req.sessionID, secrets[0], cookie.data);
+    });
+    
+    // proxy end() to commit the session
+    var _end = res.end;
+    var _write = res.write;
+    var ended = false;
+    res.end = function end(chunk, encoding) {
+      if (ended) {
+        return false;
+      }
+    
+      ended = true;
+    
+      var ret;
+      var sync = true;
+    
+      function writeend() {
+        if (sync) {
+          ret = _end.call(res, chunk, encoding);
+          sync = false;
+          return;
+        }
+    
+        _end.call(res);
+      }
+    
+      function writetop() {
+        if (!sync) {
+          return ret;
+        }
+    
+        if (chunk == null) {
+          ret = true;
+          return ret;
+        }
+    
+        var contentLength = Number(res.getHeader('Content-Length'));
+    
+        if (!isNaN(contentLength) && contentLength > 0) {
+          // measure chunk
+          chunk = !Buffer.isBuffer(chunk)
+            ? new Buffer(chunk, encoding)
+            : chunk;
+          encoding = undefined;
+    
+          if (chunk.length !== 0) {
+            debug('split response');
+            ret = _write.call(res, chunk.slice(0, chunk.length - 1));
+            chunk = chunk.slice(chunk.length - 1, chunk.length);
+            return ret;
+          }
+        }
+    
+        ret = _write.call(res, chunk, encoding);
+        sync = false;
+    
+        return ret;
+      }
+    
+      if (shouldDestroy(req)) {
+        // destroy session
+        debug('destroying');
+        store.destroy(req.sessionID, function ondestroy(err) {
+          if (err) {
+            defer(next, err);
+          }
+    
+          debug('destroyed');
+          writeend();
+        });
+    
+        return writetop();
+      }
+    
+      // no session to save
+      if (!req.session) {
+        debug('no session');
+        return _end.call(res, chunk, encoding);
+      }
+    
+      // touch session
+      req.session.touch();
+    
+      if (shouldSave(req)) {
+        req.session.save(function onsave(err) {
+          if (err) {
+            defer(next, err);
+          }
+    
+          writeend();
+        });
+    
+        return writetop();
+      } else if (options.storeImplementsTouch && shouldTouch(req)) {
+        // store implements touch method
+        debug('touching');
+        store.touch(req.sessionID, req.session, function ontouch(err) {
+          if (err) {
+            defer(next, err);
+          }
+    
+          debug('touched');
+          writeend();
+        });
+    
+        return writetop();
+      }
+    
+      return _end.call(res, chunk, encoding);
+    };
+    
+    // generate the session
+    function generate() {
+      store.generate(req);
+      originalId = req.sessionID;
+      originalHash = hash(req.session);
+      wrapmethods(req.session);
+    }
+    
+    // wrap session methods
+    function wrapmethods(sess) {
+      var _save = sess.save;
+    
+      function save() {
+        debug('saving %s', this.id);
+        savedHash = hash(this);
+        _save.apply(this, arguments);
+      }
+    
+      Object.defineProperty(sess, 'save', {
+        configurable: true,
+        enumerable: false,
+        value: save,
+        writable: true
+      });
+    }
+    
+    // check if session has been modified
+    function isModified(sess) {
+      return originalId !== sess.id || originalHash !== hash(sess);
+    }
+    
+    // check if session has been saved
+    function isSaved(sess) {
+      return originalId === sess.id && savedHash === hash(sess);
+    }
+    
+    // determine if session should be destroyed
+    function shouldDestroy(req) {
+      return req.sessionID && options.destroy && req.session == null;
+    }
+    
+    // determine if session should be saved to store
+    function shouldSave(req) {
+      // cannot set cookie without a session ID
+      if (typeof req.sessionID !== 'string') {
+        debug('session ignored because of bogus req.sessionID %o', req.sessionID);
+        return false;
+      }
+    
+      return !options.saveUninitializedSession && cookieId !== req.sessionID
+        ? isModified(req.session)
+        : !isSaved(req.session)
+    }
+    
+    // determine if session should be touched
+    function shouldTouch(req) {
+      // cannot set cookie without a session ID
+      if (typeof req.sessionID !== 'string') {
+        debug('session ignored because of bogus req.sessionID %o', req.sessionID);
+        return false;
+      }
+    
+      return cookieId === req.sessionID && !shouldSave(req);
+    }
+    
+    // determine if cookie should be set on response
+    function shouldSetCookie(req) {
+      // cannot set cookie without a session ID
+      if (typeof req.sessionID !== 'string') {
+        return false;
+      }
+    
+      // in case of rolling session, always reset the cookie
+      if (options.rollingSessions) {
+        return true;
+      }
+    
+      return cookieId != req.sessionID
+        ? options.saveUninitializedSession || isModified(req.session)
+        : req.session.cookie.expires != null && isModified(req.session);
+    }
+    
+    // generate a session if the browser doesn't send a sessionID
+    if (!req.sessionID) {
+      debug('no SID sent, generating session');
+      generate();
+      next();
+      return;
+    }
+    
+    // generate the session object
+    debug('fetching %s', req.sessionID);
+    store.get(req.sessionID, function(err, sess){
+      // error handling
+      if (err) {
+        debug('error %j', err);
+    
+        if (err.code !== 'ENOENT') {
+          next(err);
+          return;
+        }
+    
+        generate();
+      // no session
+      } else if (!sess) {
+        debug('no session found');
+        generate();
+      // populate req.session
+      } else {
+        debug('session found');
+        store.createSession(req, sess);
+        originalId = req.sessionID;
+        originalHash = hash(sess);
+    
+        if (!options.resaveSession) {
+          savedHash = originalHash
+        }
+    
+        wrapmethods(req.session);
+      }
+    
+      next();
+    });
+  };
+};
+
+/**
+ * Get the session ID cookie from request.
+ *
+ * @return {string}
+ * @private
+ */
+
+function getcookie(req, name, secrets) {
+  var header = req.headers.cookie;
+  var raw;
+  var val;
+
+  // read from cookie header
+  if (header) {
+    var cookies = cookie.parse(header);
+
+    raw = cookies[name];
+
+    if (raw) {
+      if (raw.substr(0, 2) === 's:') {
+        val = unsigncookie(raw.slice(2), secrets);
+
+        if (val === false) {
+          debug('cookie signature invalid');
+          val = undefined;
+        }
+      } else {
+        debug('cookie unsigned')
+      }
+    }
+  }
+
+  // back-compat read from cookieParser() signedCookies data
+  if (!val && req.signedCookies) {
+    val = req.signedCookies[name];
+
+    if (val) {
+      deprecate('cookie should be available in req.headers.cookie');
+    }
+  }
+
+  // back-compat read from cookieParser() cookies data
+  if (!val && req.cookies) {
+    raw = req.cookies[name];
+
+    if (raw) {
+      if (raw.substr(0, 2) === 's:') {
+        val = unsigncookie(raw.slice(2), secrets);
+
+        if (val) {
+          deprecate('cookie should be available in req.headers.cookie');
+        }
+
+        if (val === false) {
+          debug('cookie signature invalid');
+          val = undefined;
+        }
+      } else {
+        debug('cookie unsigned')
+      }
+    }
+  }
+
+  return val;
+}
+
+/**
+ * Hash the given `sess` object omitting changes to `.cookie`.
+ *
+ * @param {Object} sess
+ * @return {String}
+ * @private
+ */
+
+function hash(sess) {
+  return crc(JSON.stringify(sess, function (key, val) {
+    if (key !== 'cookie') {
+      return val;
+    }
+  }));
+}
+
+/**
+ * Determine if request is secure.
+ *
+ * @param {Object} req
+ * @param {Boolean} [trustProxy]
+ * @return {Boolean}
+ * @private
+ */
+
+function issecure(req, trustProxy) {
+  // socket is https server
+  if (req.connection && req.connection.encrypted) {
+    return true;
+  }
+
+  // do not trust proxy
+  if (trustProxy === false) {
+    return false;
+  }
+
+  // no explicit trust; try req.secure from express
+  if (trustProxy !== true) {
+    var secure = req.secure;
+    return typeof secure === 'boolean'
+      ? secure
+      : false;
+  }
+
+  // read the proto from x-forwarded-proto header
+  var header = req.headers['x-forwarded-proto'] || '';
+  var index = header.indexOf(',');
+  var proto = index !== -1
+    ? header.substr(0, index).toLowerCase().trim()
+    : header.toLowerCase().trim()
+
+  return proto === 'https';
+}
+
+/**
+ * Set cookie on response.
+ *
+ * @private
+ */
+
+function setcookie(res, name, val, secret, options) {
+  var signed = 's:' + signature.sign(val, secret);
+  var data = cookie.serialize(name, signed, options);
+
+  debug('set-cookie %s', data);
+
+  var prev = res.getHeader('set-cookie') || [];
+  var header = Array.isArray(prev) ? prev.concat(data)
+    : Array.isArray(data) ? [prev].concat(data)
+    : [prev, data];
+
+  res.setHeader('set-cookie', header)
+}
+
+/**
+ * Verify and decode the given `val` with `secrets`.
+ *
+ * @param {String} val
+ * @param {Array} secrets
+ * @returns {String|Boolean}
+ * @private
+ */
+function unsigncookie(val, secrets) {
+  for (var i = 0; i < secrets.length; i++) {
+    var result = signature.unsign(val, secrets[i]);
+
+    if (result !== false) {
+      return result;
+    }
+  }
+
+  return false;
+}

--- a/driver/header.js
+++ b/driver/header.js
@@ -2,6 +2,11 @@ var debug = require('debug')('express-session');
 var signature = require('cookie-signature');
 var crc = require('crc').crc32;
 
+/* istanbul ignore next */
+var defer = typeof setImmediate === 'function'
+  ? setImmediate
+  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
+
 module.exports = function(store, options) {
 
 	return function(req, res, next) {

--- a/driver/header.js
+++ b/driver/header.js
@@ -1,0 +1,277 @@
+var debug = require('debug')('express-session');
+var signature = require('cookie-signature');
+var crc = require('crc').crc32;
+
+module.exports = function(store, options) {
+
+	return function(req, res, next) {
+    // self-awareness
+    if (req.session) return next();
+    
+    // Handle connection as if there is no session if
+    // the store has temporarily disconnected etc
+    if (!options.storeReady) return debug('store is disconnected'), next();
+
+    var originalHash;
+    var originalId;
+    var savedHash;
+
+    // expose store
+    req.sessionStore = store;
+
+    // get the session ID from the cookie
+    var headerId = req.sessionID = getheader(req, options.name);
+
+    // proxy end() to commit the session
+    var _end = res.end;
+    var _write = res.write;
+    var ended = false;
+    res.end = function end(chunk, encoding) {
+      if (ended) {
+        return false;
+      }
+    
+      ended = true;
+
+      var ret;
+      var sync = true;
+    
+      function writeend() {
+        if (sync) {
+          ret = _end.call(res, chunk, encoding);
+          sync = false;
+          return;
+        }
+    
+        _end.call(res);
+      }
+    
+      function writetop() {
+        if (!sync) {
+          return ret;
+        }
+    
+        if (chunk == null) {
+          ret = true;
+          return ret;
+        }
+    
+        var contentLength = Number(res.getHeader('Content-Length'));
+    
+        if (!isNaN(contentLength) && contentLength > 0) {
+          // measure chunk
+          chunk = !Buffer.isBuffer(chunk)
+            ? new Buffer(chunk, encoding)
+            : chunk;
+          encoding = undefined;
+    
+          if (chunk.length !== 0) {
+            debug('split response');
+            ret = _write.call(res, chunk.slice(0, chunk.length - 1));
+            chunk = chunk.slice(chunk.length - 1, chunk.length);
+            return ret;
+          }
+        }
+    
+        ret = _write.call(res, chunk, encoding);
+        sync = false;
+    
+        return ret;
+      }
+
+      if (shouldDestroy(req)) {
+        // destroy session
+        debug('destroying');
+        store.destroy(req.sessionID, function ondestroy(err) {
+          if (err) {
+            defer(next, err);
+          }
+    
+          debug('destroyed');
+          writeend();
+        });
+    
+        return writetop();
+      }
+
+      // no session to save
+      if (!req.session) {
+        debug('no session');
+        return _end.call(res, chunk, encoding);
+      }
+
+      // touch session
+      req.session.touch();
+    
+      if (shouldSave(req)) {
+        req.session.save(function onsave(err) {
+          if (err) {
+            defer(next, err);
+          }
+    
+          writeend();
+        });
+    
+        return writetop();
+      } else if (options.storeImplementsTouch && shouldTouch(req)) {
+        // store implements touch method
+        debug('touching');
+        store.touch(req.sessionID, req.session, function ontouch(err) {
+          if (err) {
+            defer(next, err);
+          }
+    
+          debug('touched');
+          writeend();
+        });
+    
+        return writetop();
+      }
+    
+      return _end.call(res, chunk, encoding);
+    };
+
+    // generate the session
+    function generate() {
+      store.generate(req);
+      originalId = req.sessionID;
+      originalHash = hash(req.session);
+      wrapmethods(req.session);
+    }
+
+    // wrap session methods
+    function wrapmethods(sess) {
+      var _save = sess.save;
+    
+      function save() {
+        debug('saving %s', this.id);
+        savedHash = hash(this);
+        _save.apply(this, arguments);
+      }
+    
+      Object.defineProperty(sess, 'save', {
+        configurable: true,
+        enumerable: false,
+        value: save,
+        writable: true
+      });
+    }
+
+    // check if session has been modified
+    function isModified(sess) {
+      return originalId !== sess.id || originalHash !== hash(sess);
+    }
+    
+    // check if session has been saved
+    function isSaved(sess) {
+      return originalId === sess.id && savedHash === hash(sess);
+    }
+
+    // determine if session should be destroyed
+    function shouldDestroy(req) {
+      return req.sessionID && options.destroy && req.session == null;
+    }
+
+    // determine if session should be saved to store
+    function shouldSave(req) {
+      // cannot set cookie without a session ID
+      if (typeof req.sessionID !== 'string') {
+        debug('session ignored because of bogus req.sessionID %o', req.sessionID);
+        return false;
+      }
+    
+      return !options.saveUninitializedSession && headerId !== req.sessionID
+        ? isModified(req.session)
+        : !isSaved(req.session)
+    }
+
+    // determine if session should be touched
+    function shouldTouch(req) {
+      // cannot set cookie without a session ID
+      if (typeof req.sessionID !== 'string') {
+        debug('session ignored because of bogus req.sessionID %o', req.sessionID);
+        return false;
+      }
+    
+      return headerId === req.sessionID && !shouldSave(req);
+    }
+
+    // generate a session if the browser doesn't send a sessionID
+    if (!req.sessionID) {
+      debug('no SID sent, generating session');
+      generate();
+      next();
+      return;
+    }
+    
+    // generate the session object
+    debug('fetching %s', req.sessionID);
+    store.get(req.sessionID, function(err, sess){
+      // error handling
+      if (err) {
+        debug('error %j', err);
+    
+        if (err.code !== 'ENOENT') {
+          next(err);
+          return;
+        }
+    
+        generate();
+      // no session
+      } else if (!sess) {
+        debug('no session found');
+        generate();
+      // populate req.session
+      } else {
+        debug('session found');
+        store.createSession(req, sess);
+        originalId = req.sessionID;
+        originalHash = hash(sess);
+    
+        if (!options.resaveSession) {
+          savedHash = originalHash
+        }
+    
+        wrapmethods(req.session);
+      }
+    
+      next();
+    });
+	};
+};
+
+/**
+ * Get the session ID header from request.
+ *
+ * @return {string}
+ * @private
+ */
+
+function getheader(req, name) {
+  var raw = req.get(name);
+  var val;
+
+  if (raw) {
+    if (raw.substr(0, 7).toLowerCase() === 'bearer ') {
+      val = raw.slice(7);
+    }
+  }
+
+  return val;
+}
+
+/**
+ * Hash the given `sess` object omitting changes to `.cookie`.
+ *
+ * @param {Object} sess
+ * @return {String}
+ * @private
+ */
+
+function hash(sess) {
+  return crc(JSON.stringify(sess, function (key, val) {
+    if (key !== 'cookie') {
+      return val;
+    }
+  }));
+}

--- a/index.js
+++ b/index.js
@@ -11,19 +11,14 @@
  * @private
  */
 
-var cookie = require('cookie');
-var crc = require('crc').crc32;
-var debug = require('debug')('express-session');
 var deprecate = require('depd')('express-session');
-var parseUrl = require('parseurl');
-var uid = require('uid-safe').sync
-  , onHeaders = require('on-headers')
-  , signature = require('cookie-signature')
+var uid = require('uid-safe').sync;
 
 var Session = require('./session/session')
   , MemoryStore = require('./session/memory')
   , Cookie = require('./session/cookie')
   , Store = require('./session/store')
+  , CookieDriver = require('./driver/cookie')
 
 // environment
 
@@ -58,11 +53,6 @@ var warning = 'Warning: connect.session() MemoryStore is not\n'
  * @private
  */
 
-/* istanbul ignore next */
-var defer = typeof setImmediate === 'function'
-  ? setImmediate
-  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
-
 /**
  * Setup session store with the given `options`.
  *
@@ -83,16 +73,19 @@ var defer = typeof setImmediate === 'function'
 
 function session(options){
   var options = options || {}
-  //  name - previously "options.key"
-    , name = options.name || options.key || 'connect.sid'
     , store = options.store || new MemoryStore
-    , cookie = options.cookie || {}
-    , trustProxy = options.proxy
-    , storeReady = true
-    , rollingSessions = options.rolling || false;
   var resaveSession = options.resave;
   var saveUninitializedSession = options.saveUninitialized;
-  var secret = options.secret;
+  var driverOptions = {
+    name: options.name || options.key || 'connect.sid',
+    storeReady: true,
+    secret: options.secret,
+    saveUninitializedSession: options.saveUninitialized,
+    rollingSessions: options.rolling || false,
+    resaveSession: options.resave,
+    trustProxy: options.proxy,
+    cookie: options.cookie || {},
+  };
 
   var generateId = options.genid || generateSessionId;
 
@@ -100,14 +93,14 @@ function session(options){
     throw new TypeError('genid option must be a function');
   }
 
-  if (resaveSession === undefined) {
+  if (driverOptions.resaveSession === undefined) {
     deprecate('undefined resave option; provide resave option');
-    resaveSession = true;
+    driverOptions.resaveSession = true;
   }
 
-  if (saveUninitializedSession === undefined) {
+  if (driverOptions.saveUninitializedSession === undefined) {
     deprecate('undefined saveUninitialized option; provide saveUninitialized option');
-    saveUninitializedSession = true;
+    driverOptions.saveUninitializedSession = true;
   }
 
   if (options.unset && options.unset !== 'destroy' && options.unset !== 'keep') {
@@ -115,17 +108,17 @@ function session(options){
   }
 
   // TODO: switch to "destroy" on next major
-  var unsetDestroy = options.unset === 'destroy';
+  driverOptions.destroy = options.unset === 'destroy';
 
-  if (Array.isArray(secret) && secret.length === 0) {
+  if (Array.isArray(driverOptions.secret) && driverOptions.secret.length === 0) {
     throw new TypeError('secret option array must contain one or more strings');
   }
 
-  if (secret && !Array.isArray(secret)) {
-    secret = [secret];
+  if (driverOptions.secret && !Array.isArray(driverOptions.secret)) {
+    driverOptions.secret = [driverOptions.secret];
   }
 
-  if (!secret) {
+  if (!driverOptions.secret) {
     deprecate('req.secret; provide secret option');
   }
 
@@ -139,300 +132,14 @@ function session(options){
   store.generate = function(req){
     req.sessionID = generateId(req);
     req.session = new Session(req);
-    req.session.cookie = new Cookie(cookie);
+    req.session.cookie = new Cookie(driverOptions.cookie);
   };
 
-  var storeImplementsTouch = typeof store.touch === 'function';
-  store.on('disconnect', function(){ storeReady = false; });
-  store.on('connect', function(){ storeReady = true; });
+  driverOptions.storeImplementsTouch = typeof store.touch === 'function';
+  store.on('disconnect', function(){ driverOptions.storeReady = false; });
+  store.on('connect', function(){ driverOptions.storeReady = true; });
 
-  return function session(req, res, next) {
-    // self-awareness
-    if (req.session) return next();
-
-    // Handle connection as if there is no session if
-    // the store has temporarily disconnected etc
-    if (!storeReady) return debug('store is disconnected'), next();
-
-    // pathname mismatch
-    var originalPath = parseUrl.original(req).pathname;
-    if (0 != originalPath.indexOf(cookie.path || '/')) return next();
-
-    // ensure a secret is available or bail
-    if (!secret && !req.secret) {
-      next(new Error('secret option required for sessions'));
-      return;
-    }
-
-    // backwards compatibility for signed cookies
-    // req.secret is passed from the cookie parser middleware
-    var secrets = secret || [req.secret];
-
-    var originalHash;
-    var originalId;
-    var savedHash;
-
-    // expose store
-    req.sessionStore = store;
-
-    // get the session ID from the cookie
-    var cookieId = req.sessionID = getcookie(req, name, secrets);
-
-    // set-cookie
-    onHeaders(res, function(){
-      if (!req.session) {
-        debug('no session');
-        return;
-      }
-
-      var cookie = req.session.cookie;
-
-      // only send secure cookies via https
-      if (cookie.secure && !issecure(req, trustProxy)) {
-        debug('not secured');
-        return;
-      }
-
-      if (!shouldSetCookie(req)) {
-        return;
-      }
-
-      setcookie(res, name, req.sessionID, secrets[0], cookie.data);
-    });
-
-    // proxy end() to commit the session
-    var _end = res.end;
-    var _write = res.write;
-    var ended = false;
-    res.end = function end(chunk, encoding) {
-      if (ended) {
-        return false;
-      }
-
-      ended = true;
-
-      var ret;
-      var sync = true;
-
-      function writeend() {
-        if (sync) {
-          ret = _end.call(res, chunk, encoding);
-          sync = false;
-          return;
-        }
-
-        _end.call(res);
-      }
-
-      function writetop() {
-        if (!sync) {
-          return ret;
-        }
-
-        if (chunk == null) {
-          ret = true;
-          return ret;
-        }
-
-        var contentLength = Number(res.getHeader('Content-Length'));
-
-        if (!isNaN(contentLength) && contentLength > 0) {
-          // measure chunk
-          chunk = !Buffer.isBuffer(chunk)
-            ? new Buffer(chunk, encoding)
-            : chunk;
-          encoding = undefined;
-
-          if (chunk.length !== 0) {
-            debug('split response');
-            ret = _write.call(res, chunk.slice(0, chunk.length - 1));
-            chunk = chunk.slice(chunk.length - 1, chunk.length);
-            return ret;
-          }
-        }
-
-        ret = _write.call(res, chunk, encoding);
-        sync = false;
-
-        return ret;
-      }
-
-      if (shouldDestroy(req)) {
-        // destroy session
-        debug('destroying');
-        store.destroy(req.sessionID, function ondestroy(err) {
-          if (err) {
-            defer(next, err);
-          }
-
-          debug('destroyed');
-          writeend();
-        });
-
-        return writetop();
-      }
-
-      // no session to save
-      if (!req.session) {
-        debug('no session');
-        return _end.call(res, chunk, encoding);
-      }
-
-      // touch session
-      req.session.touch();
-
-      if (shouldSave(req)) {
-        req.session.save(function onsave(err) {
-          if (err) {
-            defer(next, err);
-          }
-
-          writeend();
-        });
-
-        return writetop();
-      } else if (storeImplementsTouch && shouldTouch(req)) {
-        // store implements touch method
-        debug('touching');
-        store.touch(req.sessionID, req.session, function ontouch(err) {
-          if (err) {
-            defer(next, err);
-          }
-
-          debug('touched');
-          writeend();
-        });
-
-        return writetop();
-      }
-
-      return _end.call(res, chunk, encoding);
-    };
-
-    // generate the session
-    function generate() {
-      store.generate(req);
-      originalId = req.sessionID;
-      originalHash = hash(req.session);
-      wrapmethods(req.session);
-    }
-
-    // wrap session methods
-    function wrapmethods(sess) {
-      var _save = sess.save;
-
-      function save() {
-        debug('saving %s', this.id);
-        savedHash = hash(this);
-        _save.apply(this, arguments);
-      }
-
-      Object.defineProperty(sess, 'save', {
-        configurable: true,
-        enumerable: false,
-        value: save,
-        writable: true
-      });
-    }
-
-    // check if session has been modified
-    function isModified(sess) {
-      return originalId !== sess.id || originalHash !== hash(sess);
-    }
-
-    // check if session has been saved
-    function isSaved(sess) {
-      return originalId === sess.id && savedHash === hash(sess);
-    }
-
-    // determine if session should be destroyed
-    function shouldDestroy(req) {
-      return req.sessionID && unsetDestroy && req.session == null;
-    }
-
-    // determine if session should be saved to store
-    function shouldSave(req) {
-      // cannot set cookie without a session ID
-      if (typeof req.sessionID !== 'string') {
-        debug('session ignored because of bogus req.sessionID %o', req.sessionID);
-        return false;
-      }
-
-      return !saveUninitializedSession && cookieId !== req.sessionID
-        ? isModified(req.session)
-        : !isSaved(req.session)
-    }
-
-    // determine if session should be touched
-    function shouldTouch(req) {
-      // cannot set cookie without a session ID
-      if (typeof req.sessionID !== 'string') {
-        debug('session ignored because of bogus req.sessionID %o', req.sessionID);
-        return false;
-      }
-
-      return cookieId === req.sessionID && !shouldSave(req);
-    }
-
-    // determine if cookie should be set on response
-    function shouldSetCookie(req) {
-      // cannot set cookie without a session ID
-      if (typeof req.sessionID !== 'string') {
-        return false;
-      }
-
-      // in case of rolling session, always reset the cookie
-      if (rollingSessions) {
-        return true;
-      }
-
-      return cookieId != req.sessionID
-        ? saveUninitializedSession || isModified(req.session)
-        : req.session.cookie.expires != null && isModified(req.session);
-    }
-
-    // generate a session if the browser doesn't send a sessionID
-    if (!req.sessionID) {
-      debug('no SID sent, generating session');
-      generate();
-      next();
-      return;
-    }
-
-    // generate the session object
-    debug('fetching %s', req.sessionID);
-    store.get(req.sessionID, function(err, sess){
-      // error handling
-      if (err) {
-        debug('error %j', err);
-
-        if (err.code !== 'ENOENT') {
-          next(err);
-          return;
-        }
-
-        generate();
-      // no session
-      } else if (!sess) {
-        debug('no session found');
-        generate();
-      // populate req.session
-      } else {
-        debug('session found');
-        store.createSession(req, sess);
-        originalId = req.sessionID;
-        originalHash = hash(sess);
-
-        if (!resaveSession) {
-          savedHash = originalHash
-        }
-
-        wrapmethods(req.session);
-      }
-
-      next();
-    });
-  };
+  return CookieDriver(store, driverOptions);
 };
 
 /**
@@ -444,164 +151,4 @@ function session(options){
 
 function generateSessionId(sess) {
   return uid(24);
-}
-
-/**
- * Get the session ID cookie from request.
- *
- * @return {string}
- * @private
- */
-
-function getcookie(req, name, secrets) {
-  var header = req.headers.cookie;
-  var raw;
-  var val;
-
-  // read from cookie header
-  if (header) {
-    var cookies = cookie.parse(header);
-
-    raw = cookies[name];
-
-    if (raw) {
-      if (raw.substr(0, 2) === 's:') {
-        val = unsigncookie(raw.slice(2), secrets);
-
-        if (val === false) {
-          debug('cookie signature invalid');
-          val = undefined;
-        }
-      } else {
-        debug('cookie unsigned')
-      }
-    }
-  }
-
-  // back-compat read from cookieParser() signedCookies data
-  if (!val && req.signedCookies) {
-    val = req.signedCookies[name];
-
-    if (val) {
-      deprecate('cookie should be available in req.headers.cookie');
-    }
-  }
-
-  // back-compat read from cookieParser() cookies data
-  if (!val && req.cookies) {
-    raw = req.cookies[name];
-
-    if (raw) {
-      if (raw.substr(0, 2) === 's:') {
-        val = unsigncookie(raw.slice(2), secrets);
-
-        if (val) {
-          deprecate('cookie should be available in req.headers.cookie');
-        }
-
-        if (val === false) {
-          debug('cookie signature invalid');
-          val = undefined;
-        }
-      } else {
-        debug('cookie unsigned')
-      }
-    }
-  }
-
-  return val;
-}
-
-/**
- * Hash the given `sess` object omitting changes to `.cookie`.
- *
- * @param {Object} sess
- * @return {String}
- * @private
- */
-
-function hash(sess) {
-  return crc(JSON.stringify(sess, function (key, val) {
-    if (key !== 'cookie') {
-      return val;
-    }
-  }));
-}
-
-/**
- * Determine if request is secure.
- *
- * @param {Object} req
- * @param {Boolean} [trustProxy]
- * @return {Boolean}
- * @private
- */
-
-function issecure(req, trustProxy) {
-  // socket is https server
-  if (req.connection && req.connection.encrypted) {
-    return true;
-  }
-
-  // do not trust proxy
-  if (trustProxy === false) {
-    return false;
-  }
-
-  // no explicit trust; try req.secure from express
-  if (trustProxy !== true) {
-    var secure = req.secure;
-    return typeof secure === 'boolean'
-      ? secure
-      : false;
-  }
-
-  // read the proto from x-forwarded-proto header
-  var header = req.headers['x-forwarded-proto'] || '';
-  var index = header.indexOf(',');
-  var proto = index !== -1
-    ? header.substr(0, index).toLowerCase().trim()
-    : header.toLowerCase().trim()
-
-  return proto === 'https';
-}
-
-/**
- * Set cookie on response.
- *
- * @private
- */
-
-function setcookie(res, name, val, secret, options) {
-  var signed = 's:' + signature.sign(val, secret);
-  var data = cookie.serialize(name, signed, options);
-
-  debug('set-cookie %s', data);
-
-  var prev = res.getHeader('set-cookie') || [];
-  var header = Array.isArray(prev) ? prev.concat(data)
-    : Array.isArray(data) ? [prev].concat(data)
-    : [prev, data];
-
-  res.setHeader('set-cookie', header)
-}
-
-/**
- * Verify and decode the given `val` with `secrets`.
- *
- * @param {String} val
- * @param {Array} secrets
- * @returns {String|Boolean}
- * @private
- */
-function unsigncookie(val, secrets) {
-  for (var i = 0; i < secrets.length; i++) {
-    var result = signature.unsign(val, secrets[i]);
-
-    if (result !== false) {
-      return result;
-    }
-  }
-
-  return false;
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "session/",
+    "driver/",
     "HISTORY.md",
     "LICENSE",
     "index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-session",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Simple session middleware for Express",
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
   "contributors": [


### PR DESCRIPTION
So this was my exploratory work before I knew about #164.  The idea here was basically continuing with the opinionated nature of this module, but adding support for an `Authorization` header for use with a bearer token.  Now that I see what @stalniy was doing in his PR I can see that maybe people would want a bit more flexibility.

Also worth mentioning that I don't think what is in the PR is a fully fledged option.  To be merged in this idea would need a ton of refactoring.  Also the other session backend modules would need to update, which would be a pain :)

Lastly, not sure why this particular branch is showing a commit from you, but if I were to actually make a PR that was complete I would clean it up a bunch and write tests.
