### PR TITLE
add cookieFn to dynamically create cookie options depending on request

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ var defer = typeof setImmediate === 'function'
  *
  * @param {Object} [options]
  * @param {Object} [options.cookie] Options for cookie
+ * @param {Function} [options.cookieFn] Function producing cookie options per request
  * @param {Function} [options.genid]
  * @param {String} [options.name=connect.sid] Session ID cookie name
  * @param {Boolean} [options.proxy]
@@ -87,6 +88,7 @@ function session(options){
     , name = options.name || options.key || 'connect.sid'
     , store = options.store || new MemoryStore
     , cookie = options.cookie || {}
+    , cookieFn = options.cookieFn
     , trustProxy = options.proxy
     , storeReady = true
     , rollingSessions = options.rolling || false;
@@ -98,6 +100,10 @@ function session(options){
 
   if (typeof generateId !== 'function') {
     throw new TypeError('genid option must be a function');
+  }
+
+  if (cookieFn && typeof cookieFn !== 'function') {
+    throw new TypeError('cookieFn option must be a function');
   }
 
   if (resaveSession === undefined) {
@@ -139,7 +145,7 @@ function session(options){
   store.generate = function(req){
     req.sessionID = generateId(req);
     req.session = new Session(req);
-    req.session.cookie = new Cookie(cookie);
+    req.session.cookie = new Cookie(cookieFn && cookieFn(req) || cookie);
   };
 
   var storeImplementsTouch = typeof store.touch === 'function';

--- a/test/session.js
+++ b/test/session.js
@@ -638,6 +638,21 @@ describe('session()', function(){
     })
   })
 
+  describe('cookieFn option', function(){
+    it('should reject non-function values', function(){
+      assert.throws(session.bind(null, { cookieFn: 'bogus!' }), /cookieFn.*must/)
+    });
+
+    it('should allow custom function', function(done){
+      function cookieFn(req) { return { domain: req.url } }
+
+      request(createServer({ cookieFn: cookieFn }))
+      .get('/abc')
+      .expect(shouldSetCookieToDomain('connect.sid', '/abc'))
+      .expect(200, done)
+    });
+  })
+
   describe('genid option', function(){
     it('should reject non-function values', function(){
       assert.throws(session.bind(null, { genid: 'bogus!' }), /genid.*must/)
@@ -2069,6 +2084,15 @@ function shouldSetCookieToValue(name, val) {
     assert.ok(header, 'should have a cookie header')
     assert.equal(header.split('=')[0], name, 'should set cookie ' + name)
     assert.equal(header.split('=')[1].split(';')[0], val, 'should set cookie ' + name + ' to ' + val)
+  }
+}
+
+function shouldSetCookieToDomain(name, val) {
+  return function (res) {
+    var header = cookie(res);
+    assert.ok(header, 'should have a cookie header')
+    assert.equal(header.split('=')[0], name, 'should set cookie ' + name)
+    assert.equal(header.split('=')[2].split(';')[0], val, 'should set cookie ' + name + ' to ' + val)
   }
 }
 


### PR DESCRIPTION
I have a backend that runs on more than one domain and depending from which domain request comes from, I'd like the session cookie to point to that domain.

Currently this is not possible, because you can only specify one domain in cookie.domain option.

One way to solve this problem is to have a configurable function that is called for each request to produce cookie options. This is what my pull-request adds. I'd be happy to hear your comments.