### PR TITLE
Add support for Secret function

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,21 @@ The function should return a string or array of strings to be used as the secret
 signing the cookie.
 
 ```js
+var rotatingSecretKey;
+function rotateKey() {
+    rotatingSecretKey = Math.random();
+}
+// Initial rotation.
+rotateKey();
+
+setInterval(rotateKey, 60 * 60 * 1000) // Rotate the key at least once an hour.
 app.use(function(req, res, next) {
   var subdomain = subdomain[0];
-  req.clientSecret = getClientKey(subdomain);
 });
+
 app.use(session({
-  secret: function (req) { 
-    return 'Danger Zone!' + req.clientSecret;
+  secret: function () { 
+    return rotatingSecretKey;
   }
 }))
 ```

--- a/README.md
+++ b/README.md
@@ -135,9 +135,24 @@ it to be saved.
 **Required option**
 
 This is the secret used to sign the session ID cookie. This can be either a string
-for a single secret, or an array of multiple secrets. If an array of secrets is
+for a single secret, an array of multiple secrets, or a function. If an array of secrets is
 provided, only the first element will be used to sign the session ID cookie, while
-all the elements will be considered when verifying the signature in requests.
+all the elements will be considered when verifying the signature in requests. If a function
+is provided then it will be executed with `req` as the first parameter for each request.
+The function should return a string or array of strings to be used as the secret for 
+signing the cookie.
+
+```js
+app.use(function(req, res, next) {
+  var subdomain = subdomain[0];
+  req.clientSecret = getClientKey(subdomain);
+});
+app.use(session({
+  secret: function (req) { 
+    return 'Danger Zone!' + req.clientSecret;
+  }
+}))
+```
 
 ##### store
 

--- a/test/session.js
+++ b/test/session.js
@@ -2278,19 +2278,6 @@ function sid(res) {
   return val
 }
 
-function subdomains(hostname) {
-  if (!hostname) {
-    return [];
-  }
-
-  var offset = 2;
-  return hostname.split('.').reverse().slice(offset);
-}
-
-function hostname(req) {
-  return req.headers.host;
-}
-
 function writePatch() {
   var ended = false
   return function addWritePatch(req, res, next) {


### PR DESCRIPTION
This PR adds the ability for a function to be specified for the `secret` option. When a function is passed it is called with `req` passed to it so that the secret can be varied based upon an incoming request. Additionally, this adds corresponding tests and documentation.

The reason for this is that for my implementation I need the ability to vary my secret based upon an incoming request. In my case I'm wanting to reduce my resource usage (memory & server) by keeping multiple `express-session` instances in memoized and in memory and then manually changing them based on the request.

Here's a trivial example of what I'm having to do right now:

``` js
var memoizedSessions = {};
app.use(function (req, res, next) {
    if (!memoizedSessions[req.client]) {
        memoizedSessions[req.client] = session({
            secret: 'keyboard cat' + req.client
        });
    }

    memoizedSessions[req.client](req, res, next);
});
```

For this implementation I started off with the simplest path that I could see to getting the changes in there. The only other method I saw was that I could update the functions to pass `req` around, but I don't think that will result in more performance but instead just passing around of the variable to multiple functions.
