### PR TITLE
make sure cookie is not undefined

### DIFF
--- a/session/store.js
+++ b/session/store.js
@@ -74,6 +74,10 @@ Store.prototype.load = function(sid, fn){
  */
 
 Store.prototype.createSession = function(req, sess){
+  if(typeof sess.cookie == 'undefined') {
+  	sess.cookie = {};
+  }
+
   var expires = sess.cookie.expires
     , orig = sess.cookie.originalMaxAge;
   sess.cookie = new Cookie(sess.cookie);


### PR DESCRIPTION
Was having sess.cookie show up undefined sometimes, and it was crashing my server when it tried to read the expire property. This doesn't fix the root of the bug but it does stop the process from crashing in the meantime. This error was also fixed by clearing my browser cache. The client side shouldn't be able to crash the process.