### PR TITLE
Prevent the `rolling: true` option from overriding the `saveUnitialized: false` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ likely need `resave: true`.
 
 ##### rolling
 
-Force a cookie to be set on every response. This resets the expiration date.
+Force a cookie to be set with its [`maxAge`](#cookiemaxage) reset to its original value on every response, thus continually extending the expiration date.
 
 The default value is `false`.
+
+**Note** When this option is set to `true` but the [`saveUnitialized` option](#saveUnitialized) is set to `false`, the cookie will only be set on responses _after_ the session has been saved for the first time.
 
 ##### saveUninitialized
 

--- a/index.js
+++ b/index.js
@@ -385,14 +385,18 @@ function session(options){
         return false;
       }
 
-      // in case of rolling session, always reset the cookie
-      if (rollingSessions) {
-        return true;
+      // For new sessions...
+      if (cookieId != req.sessionID) {
+        return saveUninitializedSession || isModified(req.session);
       }
-
-      return cookieId != req.sessionID
-        ? saveUninitializedSession || isModified(req.session)
-        : req.session.cookie.expires != null && isModified(req.session);
+      // For existing sessions...
+      else {
+        // In case of rolling sessions, always extend the cookie's expiration date
+        if (rollingSessions) {
+          return true;
+        }
+        return req.session.cookie.expires != null && isModified(req.session);
+      }
     }
 
     // generate a session if the browser doesn't send a sessionID


### PR DESCRIPTION
Prevent the `rolling: true` option from overriding the `saveUnitialized: false` option.

Fixes #239.