### PR TITLE
Add "nedb-session-store" to session store list

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,10 @@ and other multi-core embedded devices).
 [mssql-session-store-url]: https://www.npmjs.com/package/mssql-session-store
 [mssql-session-store-image]: https://img.shields.io/github/stars/jwathen/mssql-session-store.svg?label=%E2%98%85
 
+[![Github Stars][nedb-session-store-image] nedb-session-store][nedb-session-store-url] An alternate NeDB-based (either in-memory or file-persisted) session store.
+[nedb-session-store-url]: https://www.npmjs.com/package/nedb-session-store
+[nedb-session-store-image]: https://img.shields.io/github/stars/JamesMGreene/nedb-session-store.svg?label=%E2%98%85
+
 [![Github Stars][session-file-store-image] session-file-store][session-file-store-url] A file system-based session store.
 [session-file-store-url]: https://www.npmjs.com/package/session-file-store
 [session-file-store-image]: https://img.shields.io/github/stars/valery-barysok/session-file-store.svg?label=%E2%98%85


### PR DESCRIPTION
When I tried out the listed "express-nedb-session" session store implementation, I found its Connect/Express version support, configuration options, and completeness of the session store API implementation to be pretty limited.

As such, I ended up writing a new implementation called "nedb-session-store" to meet our business needs.

**Resources:**  
 - https://www.npmjs.com/package/nedb-session-store
 - https://github.com/JamesMGreene/nedb-session-store