### PR TITLE
BUG: Add test for incorrect Content-Length with async touch

### DIFF
--- a/test/session.js
+++ b/test/session.js
@@ -256,21 +256,13 @@ describe('session()', function(){
   })
 
   describe('when response ended', function () {
-    it('should not remove the last byte', function (done) {
-      var store = new session.MemoryStore();
-      // async
-      store.touch = function (sid, sess, fn) {
-        setTimeout(function () {
-          fn()
-        }, 5 * 1000)
-      };
+    it('should not remove the last byte when errors', function (done) {
       var app = express()
         .use(session({
-          store: store,
+          store: new session.MemoryStore(),
           secret: 'keyboard cat',
           resave: false
         }))
-
       var msg = 'I am the message. Don\'t strip my last byte'
       app.get('/', function (req, res, next) {
         // The following instrumentation is useful to debug


### PR DESCRIPTION
Add a test case for a bug I found in the wild when using express-session with Error middlewares. It results in the http socket being destroyed before the response body is fully written.

Because of this response body slicing
https://github.com/expressjs/session/commit/5c503e7552ea48342f4ce4ce1322606eb8ee217c#diff-168726dbe96b3ce427e7fedce31bb0bcR226

And then finalhandler destroys the `req.socket`, which `=== res.socket`
https://github.com/pillarjs/finalhandler/blob/master/index.js#L104

And so then the response can't get that last byte to the client, and the Content-Length is then off by one

And Chrome complains: `Failed to load resource: net::ERR_INCOMPLETE_CHUNKED_ENCODING`
And curl: `curl: (18) transfer closed with 1 bytes remaining to read`

I tried quite a few ways of changing finalhandler to not destroy the socket, or wait for some stream events, but can't figure it out.

Any ideas, even for workarounds, are greatly appreciated :)

great libs
