### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ request).
 
 The default value is `'connect.sid'`.
 
-**Note** if you have multiple apps running on the same host (hostname + port),
+**Note** if you have multiple apps running on the same hostname,
 then you need to separate the session cookies from each other. The simplest
 method is to simply set different `name`s per app.
 


### PR DESCRIPTION
Cookies are sent per hostname irrespective of port ( http://stackoverflow.com/questions/1612177/are-http-cookies-port-specific ) the documentation suggests that they are unique per hostname and port combination although this is not the case.

In that respect it is actually irrelevant if the servers are running on the same physical host, but only if the the hostname is the same for accessing the two applications.