### PR TITLE
saveUnintialized typo fix in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ countdown.
 
 The default value is `false`.
 
-**Note** When this option is set to `true` but the `saveUnitialized` option is
+**Note** When this option is set to `true` but the `saveUninitialized` option is
 set to `false`, the cookie will not be set on a response with an uninitialized
 session.
 


### PR DESCRIPTION
I was referencing the misspelled version and kept getting deprecated errors.  
Fixed misspelling of saveUnintialized on line 118.