### PR TITLE
Fix bug: cookie.expires not modified even if maxAge set

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-unreleased
-==========
+1.13.1 / 2016-01-29
+===================
 
   * deps: parseurl@~1.3.1
     - perf: enable strict mode

--- a/index.js
+++ b/index.js
@@ -203,6 +203,7 @@ function session(options){
         return;
       }
 
+      cookie.originalMaxAge > 0 && (cookie.expires = new Date(Date.now() + cookie.originalMaxAge));
       setcookie(res, name, req.sessionID, secrets[0], cookie.data);
     });
 

--- a/index.js
+++ b/index.js
@@ -203,7 +203,10 @@ function session(options){
         return;
       }
 
-      cookie.originalMaxAge > 0 && (cookie.expires = new Date(Date.now() + cookie.originalMaxAge));
+      if (cookie.originalMaxAge > 0) {
+        cookie.expires = new Date(Date.now() + cookie.originalMaxAge);
+      }
+
       setcookie(res, name, req.sessionID, secrets[0], cookie.data);
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-session",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Simple session middleware for Express",
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
   "contributors": [

--- a/test/session.js
+++ b/test/session.js
@@ -2117,7 +2117,7 @@ describe('session()', function(){
   })
 
   describe('cookie.expire', function(){
-    this.timeout(86400000);
+    this.timeout(12000);
     var val;
 
     var app = express()


### PR DESCRIPTION
ref: https://github.com/expressjs/session/issues/276. 

Hi, i found when access server at second time, cookie.expire will not be modified even if i set maxAge and rolling:true.

Here is my test code. 

```
var express = require('express');
var path = require('path');
var cookieParser = require('cookie-parser');
var bodyParser = require('body-parser');
var session = require('express-session');

var app = express();

// Use the session middleware
app.use(session({
  secret: 'keyboard cat',
  rolling: true,
  saveUninitialized: true,
  resave: true,
  cookie: { maxAge: 10000 }}))

// Access the session as req.session
app.get('/', function(req, res, next) {
  var sess = req.session
  if (sess.views) {
    sess.views++
    res.setHeader('Content-Type', 'text/html')
    res.write('<p>views: ' + sess.views + '</p>')
    res.write('<p>expires in: ' + (sess.cookie.maxAge / 1000) + 's</p>')
    res.end()
  } else {
    sess.views = 1
    res.end('welcome to the session demo. refresh!')
  }
});
```

In above example, i set **maxAge** to **10** seconds, and **rolling:true**, and saveUninitialized:true. Other settings seems have no effect to this problem.

I run this code, then use following curl command line to test and see verbose output:
```
$ curl --verbose --cookie cookie --cookie-jar cookie http://localhost:3000
* Rebuilt URL to: http://localhost:3000/
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< X-Powered-By: Express
* Replaced cookie connect.sid="s%3AGRecnYYVv0WP0plY8qrIvV4EHG82Ts8h.aGG7rL0Fdb4fiXS0zN3u5eC9h%2BY8adZgZxzpyFZWFNs" for domain localhost, path /, expire 1455991539
< set-cookie: connect.sid=s%3AGRecnYYVv0WP0plY8qrIvV4EHG82Ts8h.aGG7rL0Fdb4fiXS0zN3u5eC9h%2BY8adZgZxzpyFZWFNs; Path=/; Expires=Sat, 20 Feb 2016 18:05:39 GMT; HttpOnly
< Date: Sat, 20 Feb 2016 18:05:29 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
welcome to the session demo. refresh!
```

After about 5 seconds, i run the command line again, it will use same cookie from last response.
```
$ curl --verbose --cookie cookie --cookie-jar cookie http://localhost:3000
* Rebuilt URL to: http://localhost:3000/
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.43.0
> Accept: */*
> Cookie: connect.sid=s%3AGRecnYYVv0WP0plY8qrIvV4EHG82Ts8h.aGG7rL0Fdb4fiXS0zN3u5eC9h%2BY8adZgZxzpyFZWFNs
> 
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Content-Type: text/html
* Replaced cookie connect.sid="s%3AGRecnYYVv0WP0plY8qrIvV4EHG82Ts8h.aGG7rL0Fdb4fiXS0zN3u5eC9h%2BY8adZgZxzpyFZWFNs" for domain localhost, path /, expire 1455991539
< set-cookie: connect.sid=s%3AGRecnYYVv0WP0plY8qrIvV4EHG82Ts8h.aGG7rL0Fdb4fiXS0zN3u5eC9h%2BY8adZgZxzpyFZWFNs; Path=/; Expires=Sat, 20 Feb 2016 18:05:39 GMT; HttpOnly
< Date: Sat, 20 Feb 2016 18:05:35 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
<p>views: 2</p><p>expires in: 4.065s</p>
```

**Please notice the expire of second response, i'v set maxAge to 10 seconds, but cookie's expire will be:**
```
        Expires=Sat, 20 Feb 2016 18:05:39 GMT
Current time is: Sat, 20 Feb 2016 18:05:35 GMT
```
It means expire after 4 seconds, this is not by-design obviously.

I checked source code in <a href="https://github.com/expressjs/session/blob/master/index.js">index.js</a>, line 206:

```
    onHeaders(res, function(){
      ... ...
      var cookie = req.session.cookie;
      ... ...
//line 206:
      setcookie(res, name, req.sessionID, secrets[0], cookie.data);
```
**I insert following code to line 206 to change cookie.**expire** then works!**
```
      cookie.originalMaxAge > 0 && (cookie.expires = new Date(Date.now() + cookie.originalMaxAge));
```

I hope you can check this and merge it.
