### PR TITLE
Add missing sameSite property on cookie data object.

### DIFF
--- a/session/cookie.js
+++ b/session/cookie.js
@@ -102,6 +102,7 @@ Cookie.prototype = {
       , httpOnly: this.httpOnly
       , domain: this.domain
       , path: this.path
+      , sameSite: this.sameSite
     }
   },
 


### PR DESCRIPTION
The sameSite property is not working. I just added the sameSite property on cookie data object.