### PR TITLE
Adding Medea session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,11 @@ and other multi-core embedded devices).
 [level-session-store-url]: https://www.npmjs.com/package/level-session-store
 [level-session-store-image]: https://img.shields.io/github/stars/scriptollc/level-session-store.svg?label=%E2%98%85
 
+[![★][medea-session-store-image] medea-session-store][medea-session-store-url] A Medea-based session store.
+
+[medea-session-store-url]: https://www.npmjs.com/package/medea-session-store
+[medea-session-store-image]: https://img.shields.io/github/stars/scriptollc/medea-session-store.svg?label=%E2%98%85
+
 [![★][mssql-session-store-image] mssql-session-store][mssql-session-store-url] A SQL Server-based session store.
 
 [mssql-session-store-url]: https://www.npmjs.com/package/mssql-session-store


### PR DESCRIPTION
Hi,

Based on the level-session-store of Scripto, I've adapted a medea-session-store. 
The idea behind it is that it is fully functional on Android (as medeadown works easily on android but leveldown not).

Thank you for adding it.