### PR TITLE
fixed "Max age resetting after response #2" open issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ function session(options) {
 
       return cookieId != req.sessionID
         ? saveUninitializedSession || isModified(req.session)
-        : rollingSessions && req.session.cookie.expires && isModified(req.session);
+        : rollingSessions || req.session.cookie.expires && isModified(req.session);
     }
 
     // generate a session if the browser doesn't send a sessionID

--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ function session(options) {
 
       return cookieId != req.sessionID
         ? saveUninitializedSession || isModified(req.session)
-        : rollingSessions || req.session.cookie.expires != null && isModified(req.session);
+        : rollingSessions && req.session.cookie.expires && isModified(req.session);
     }
 
     // generate a session if the browser doesn't send a sessionID

--- a/session/memory.js
+++ b/session/memory.js
@@ -149,6 +149,7 @@ MemoryStore.prototype.touch = function touch(sessionId, session, callback) {
 
   if (currentSession) {
     // update expiration
+    console.log("THIS IS SEESSSSION COOKIEEE", session.cookie)
     currentSession.cookie = session.cookie
     this.sessions[sessionId] = JSON.stringify(currentSession)
   }

--- a/session/memory.js
+++ b/session/memory.js
@@ -149,7 +149,6 @@ MemoryStore.prototype.touch = function touch(sessionId, session, callback) {
 
   if (currentSession) {
     // update expiration
-    console.log("THIS IS SEESSSSION COOKIEEE", session.cookie)
     currentSession.cookie = session.cookie
     this.sessions[sessionId] = JSON.stringify(currentSession)
   }


### PR DESCRIPTION
https://github.com/expressjs/session/issues/2

This issue did not allow users to specify a boolean for rolling (property when setting cookie). After this fix, rolling can be set to boolean and works.
