### PR TITLE
Fixed issue #2 "Max age resetting after response #2"

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ function session(options) {
 
       return cookieId != req.sessionID
         ? saveUninitializedSession || isModified(req.session)
-        : rollingSessions || req.session.cookie.expires != null && isModified(req.session);
+        : rollingSessions || req.session.cookie.expires && isModified(req.session);
     }
 
     // generate a session if the browser doesn't send a sessionID


### PR DESCRIPTION
Link to issue: https://github.com/expressjs/session/issues/2

Fixed the `shouldSetCookie` function which prevented `rollingSessions` from accepting a boolean value and working. You are now able to enable rolling based on the boolean value you provide. The default value is `false`. Rolling now works.
