### PR TITLE
Remove buffer deprecated warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "cookie": "0.3.1",
     "cookie-signature": "1.0.6",
-    "crc": "3.4.1",
+    "crc": "3.4.3",
     "debug": "2.3.2",
     "depd": "~1.1.0",
     "on-headers": "~1.0.1",


### PR DESCRIPTION
crc 3.4.2/3 -- have replace buffer() with new Buffer(), hence remove the deprecation warning