### PR TITLE
feat: Option to allow regenerate() to preserve old session

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,15 +304,31 @@ app.get('/', function(req, res, next) {
 })
 ```
 
-#### Session.regenerate(callback)
+#### Session.regenerate([options], callback)
 
-To regenerate the session simply invoke the method. Once complete,
+Regenerates the session for the current request. Once complete,
 a new SID and `Session` instance will be initialized at `req.session`
 and the `callback` will be invoked.
 
+#### Options
+
+If the options argument is omitted, the options will take their default values.
+The following options are supported:
+
+##### destroy
+
+Specifies whether the existing session should be destroyed or not. Defaults
+to `true`, and the existing session will be destroyed. If this is not desirable,
+set to `false` to preserve the existing session.
+
 ```js
 req.session.regenerate(function(err) {
-  // will have a new session here
+  // existing session is destroyed and will have a new session here
+})
+```
+```js
+req.session.regenerate({ destroy: false }, function(err) {
+  // existing session is preserved but will have a new session here
 })
 ```
 

--- a/session/session.js
+++ b/session/session.js
@@ -120,8 +120,8 @@ defineMethod(Session.prototype, 'destroy', function destroy(fn) {
  * @api public
  */
 
-defineMethod(Session.prototype, 'regenerate', function regenerate(fn) {
-  this.req.sessionStore.regenerate(this.req, fn);
+defineMethod(Session.prototype, 'regenerate', function regenerate(options, fn) {
+  this.req.sessionStore.regenerate(this.req, options, fn);
   return this;
 });
 

--- a/session/store.js
+++ b/session/store.js
@@ -47,12 +47,31 @@ util.inherits(Store, EventEmitter)
  * @api public
  */
 
-Store.prototype.regenerate = function(req, fn){
+Store.prototype.regenerate = function regenerate (req, options, fn) {
+  var cb = fn
+  var opts = options || {}
   var self = this;
-  this.destroy(req.sessionID, function(err){
-    self.generate(req);
-    fn(err);
-  });
+
+  if (typeof options === 'function') {
+    cb = options
+    opts = {}
+  }
+
+  var destroy = opts.destroy !== undefined
+    ? opts.destroy
+    : true
+
+  if (destroy) {
+    this.destroy(req.sessionID, function (err) {
+      self.generate(req)
+      cb(err)
+    })
+  } else {
+    process.nextTick(function () {
+      self.generate(req)
+      cb(null)
+    })
+  }
 };
 
 /**


### PR DESCRIPTION
Add preserve option to session.regenerate() function for use cases when it is desirable to regenerate the session, but not destroy the old session immediately. For example when there could be multiple ajax requests inflight with the old session id.

Existing functionality is preserved if the option is omitted. Existing test was improved to cover session destuction and new test was added for the preserve case.

This was motivated by the desire to implement middleware to provide session renewal, as recommended by [OWASP](https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Renewal_Timeout)