### PR TITLE
add parametrizable get/setcookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,36 +280,28 @@ The default value is `'keep'`.
   - `'keep'` The session in the store will be kept, but modifications made during
     the request are ignored and not saved.
 
-##### getcookie
 
-Allows to specify a custom function to read and parse the cookie.
+##### getcookie, setcookie
 
-Warning the function signature is subject to change in the future, this option is unsafe
+Allows to specify custom functions to parse and set cookies.
+
+Warnings: 
+ - cookies must be parsed accordingly to how they are set of course
+ - the function signatures are subject to change in the future
 
 ```js
 app.use(session({
+  name: sessionKey,
+  secret: sessionSecret,
   getcookie(req) { // full signature is (req, name, secrets)
     var cookies = cookie.parse(headers.cookie || headers.authorization || '');
     return signature.unsign(cookies[sessionKey] || '', sessionSecret);
   },
-  secret: 'keyboard cat'
-}))
-```
-
-
-##### setcookie
-
-Similarly to getookie, it allows to specify a custom function to set cookie.
-
-Warning again, the function signature is subject to change in the future,
-and should be used carefully like getcookie
-
-```js
-app.use(session({
   setcookie(res, name, val, secret, options) {
-    var signed = signature.sign(val, secret);
-    var data = cookie.serialize(name, signed, options);
+    var signed = signature.sign(val, sessionSecret);
+    var data = cookie.serialize(sessionKey, signed, options);
     res.setHeader('set-cookie', data);
+    res.setHeader('Access-Control-Expose-Headers', 'Authorization');
     res.setHeader('authorization', data);
   },
   secret: 'keyboard cat'

--- a/README.md
+++ b/README.md
@@ -280,6 +280,42 @@ The default value is `'keep'`.
   - `'keep'` The session in the store will be kept, but modifications made during
     the request are ignored and not saved.
 
+##### getcookie
+
+Allows to specify a custom function to read and parse the cookie.
+
+Warning the function signature is subject to change in the future, this option is unsafe
+
+```js
+app.use(session({
+  getcookie(req) { // full signature is (req, name, secrets)
+    var cookies = cookie.parse(headers.cookie || headers.authorization || '');
+    return signature.unsign(cookies[sessionKey] || '', sessionSecret);
+  },
+  secret: 'keyboard cat'
+}))
+```
+
+
+##### setcookie
+
+Similarly to getookie, it allows to specify a custom function to set cookie.
+
+Warning again, the function signature is subject to change in the future,
+and should be used carefully like getcookie
+
+```js
+app.use(session({
+  setcookie(res, name, val, secret, options) {
+    var signed = signature.sign(val, secret);
+    var data = cookie.serialize(name, signed, options);
+    res.setHeader('set-cookie', data);
+    res.setHeader('authorization', data);
+  },
+  secret: 'keyboard cat'
+}))
+```
+
 ### req.session
 
 To store or access session data, simply use the request property `req.session`,

--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@ function session(options) {
   // get the save uninitialized session option
   var saveUninitializedSession = opts.saveUninitialized
 
+  // get optional getcookie and setcookie custom functions
+  var getcookie = opts.getcookie || getcookieDefault;
+  var setcookie = opts.setcookie || setcookieDefault;
+
   // get the cookie signing secret
   var secret = opts.secret
 
@@ -509,7 +513,7 @@ function generateSessionId(sess) {
  * @private
  */
 
-function getcookie(req, name, secrets) {
+function getcookieDefault(req, name, secrets) {
   var header = req.headers.cookie;
   var raw;
   var val;
@@ -631,7 +635,7 @@ function issecure(req, trustProxy) {
  * @private
  */
 
-function setcookie(res, name, val, secret, options) {
+function setcookieDefault(res, name, val, secret, options) {
   var signed = 's:' + signature.sign(val, secret);
   var data = cookie.serialize(name, signed, options);
 

--- a/test/getcookie.js
+++ b/test/getcookie.js
@@ -1,0 +1,74 @@
+'use strict';
+process.env.NO_DEPRECATION = 'express-session';
+
+var after = require('after')
+var assert = require('assert')
+var express = require('express')
+  , request = require('supertest')
+  , cookieParser = require('cookie-parser')
+  , session = require('../')
+  , Cookie = require('../session/cookie')
+var fs = require('fs')
+var http = require('http')
+var https = require('https')
+var util = require('util')
+var cookie = require('cookie')
+var signature = require('cookie-signature')
+
+var min = 60 * 1000;
+
+describe('session getcookie()', function(){
+
+  var sessionKey = 'foo';
+  var sessionSecret = 'bar';
+
+  var app = express()
+    .use(session({ 
+      name: sessionKey, 
+      secret: sessionSecret,
+      getcookie: function(req) {
+        var cookies = cookie.parse(req.headers.authorization || '');
+        return signature.unsign(cookies[sessionKey] || '', sessionSecret);
+      },
+      setcookie: function(res, name, val, secret, options) {
+        var signed = signature.sign(val, secret);
+        var data = cookie.serialize(name, signed, options);
+        // res.setHeader('Access-Control-Expose-Headers', 'Authorization'); necessary with cors
+        res.setHeader('authorization', data);
+      }
+    }))
+    .post('/', function(req, res) {
+      req.session.user = 'John';
+      return res.json({ok: 1})
+    })
+    .get('/', function(req, res) {
+      res.json({user: req.session.user});
+    });
+
+
+  var data;
+
+  it('should set a session, and send it in authorization header', function(done){
+
+    request(app)
+    .post('/')
+    .expect(function (res) {
+      data = res.headers.authorization;
+    })
+    .expect(200, done)
+  })
+
+  it('should get the session using authorization header', function(done){
+
+    request(app)
+    .get('/')
+    .set('Authorization', data)
+    .expect(function (res) {
+      assert.equal(res.body.user, 'John')
+    })
+    .expect(200, done)
+
+  })
+
+})
+

--- a/test/session.js
+++ b/test/session.js
@@ -2084,6 +2084,8 @@ describe('session()', function(){
   })
 })
 
+
+
 function cookie(res) {
   var setCookie = res.headers['set-cookie'];
   return (setCookie && setCookie[0]) || undefined;


### PR DESCRIPTION
usage: 


```js
session({
	...
	getcookie({headers}, name, secrets) {
		if (headers.cookie) {
			var cookies = cookie.parse(headers.cookie);
			return signature.unsign(cookies[name] || '', secrets[0]);
		}
		else if (headers.authorization) {
			return signature.unsign(headers.authorization || '', secrets[0]);
		}
		return null;
	},
	setcookie(res, name, val, secret, options) {
		var signed = signature.sign(val, secret);
		var data = cookie.serialize(name, signed, options);

		var prev = res.getHeader('set-cookie') || [];
		var header = Array.isArray(prev) ? prev.concat(data) : [prev, data];

		res.setHeader('set-cookie', header);
		res.setHeader('authorization', data);
	}
})

```