### PR TITLE
Make variable type checks consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var warning = 'Warning: connect.session() MemoryStore is not\n'
  */
 
 /* istanbul ignore next */
-var defer = typeof setImmediate === 'function'
+var defer = typeof setImmediate == 'function'
   ? setImmediate
   : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
 
@@ -113,7 +113,7 @@ function session(options) {
   // get the cookie signing secret
   var secret = opts.secret
 
-  if (typeof generateId !== 'function') {
+  if (typeof generateId != 'function') {
     throw new TypeError('genid option must be a function');
   }
 
@@ -164,7 +164,7 @@ function session(options) {
     }
   };
 
-  var storeImplementsTouch = typeof store.touch === 'function';
+  var storeImplementsTouch = typeof store.touch == 'function';
 
   // register event listeners for the store to track readiness
   var storeReady = true
@@ -414,7 +414,7 @@ function session(options) {
     // determine if session should be saved to store
     function shouldSave(req) {
       // cannot set cookie without a session ID
-      if (typeof req.sessionID !== 'string') {
+      if (typeof req.sessionID != 'string') {
         debug('session ignored because of bogus req.sessionID %o', req.sessionID);
         return false;
       }
@@ -427,7 +427,7 @@ function session(options) {
     // determine if session should be touched
     function shouldTouch(req) {
       // cannot set cookie without a session ID
-      if (typeof req.sessionID !== 'string') {
+      if (typeof req.sessionID != 'string') {
         debug('session ignored because of bogus req.sessionID %o', req.sessionID);
         return false;
       }
@@ -438,7 +438,7 @@ function session(options) {
     // determine if cookie should be set on response
     function shouldSetCookie(req) {
       // cannot set cookie without a session ID
-      if (typeof req.sessionID !== 'string') {
+      if (typeof req.sessionID != 'string') {
         return false;
       }
 
@@ -610,7 +610,7 @@ function issecure(req, trustProxy) {
   // no explicit trust; try req.secure from express
   if (trustProxy !== true) {
     var secure = req.secure;
-    return typeof secure === 'boolean'
+    return typeof secure == 'boolean'
       ? secure
       : false;
   }

--- a/session/memory.js
+++ b/session/memory.js
@@ -22,7 +22,7 @@ var util = require('util')
  */
 
 /* istanbul ignore next */
-var defer = typeof setImmediate === 'function'
+var defer = typeof setImmediate == 'function'
   ? setImmediate
   : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
 
@@ -171,7 +171,7 @@ function getSession(sessionId) {
   // parse
   sess = JSON.parse(sess)
 
-  var expires = typeof sess.cookie.expires === 'string'
+  var expires = typeof sess.cookie.expires == 'string'
     ? new Date(sess.cookie.expires)
     : sess.cookie.expires
 

--- a/session/session.js
+++ b/session/session.js
@@ -25,7 +25,7 @@ function Session(req, data) {
   Object.defineProperty(this, 'req', { value: req });
   Object.defineProperty(this, 'id', { value: req.sessionID });
 
-  if (typeof data === 'object' && data !== null) {
+  if (typeof data == 'object' && data !== null) {
     // merge data into this, ignoring prototype properties
     for (var prop in data) {
       if (!(prop in this)) {


### PR DESCRIPTION
Whenever you use the `typeof` operator, you are guaranteed to be working with
strings, as this is what typeof returns. For this reason it is generally a good
idea to use the equality operator instead of the strict equality operator for
comparisons.

This is a minor change and it is consistent with other areas of the code where
the equality operator is already in use, e.g. [session/session.js](https://github.com/expressjs/session/blob/8e57b21bef0d53010c4d37f4beee3f0341f3eaa6/session/cookie.js#L72)