### PR TITLE
Update documentation for Session.touch()

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,10 +360,9 @@ req.session.save(function(err) {
 })
 ```
 
-#### Session.touch()
+#### Session.touch(callback)
 
-Updates the `.maxAge` property. Typically this is
-not necessary to call, as the session middleware does this for you.
+Updates the `.maxAge` property. This is done automatically when `rolling` is `true`.
 
 ### req.session.id
 


### PR DESCRIPTION
Session.touch takes a callback as argument
The `.maxAge` property is only updated when `rolling` is `true`

Information from http://stackoverflow.com/questions/14464873/expressjs-session-expiring-despite-activity