### PR TITLE
Ensure the session is saved before sending first chunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,10 +308,11 @@ function session(options) {
           }
 
           debug('destroyed');
+          writetop();
           writeend();
         });
 
-        return writetop();
+        return;
       }
 
       // no session to save
@@ -332,10 +333,11 @@ function session(options) {
             defer(next, err);
           }
 
+          writetop();
           writeend();
         });
 
-        return writetop();
+        return
       } else if (storeImplementsTouch && shouldTouch(req)) {
         // store implements touch method
         debug('touching');
@@ -345,10 +347,11 @@ function session(options) {
           }
 
           debug('touched');
+          writetop();
           writeend();
         });
 
-        return writetop();
+        return
       }
 
       return _end.call(res, chunk, encoding);


### PR DESCRIPTION
For now if asyncronous session saving takes little more then reading, you start dealing with the problem described in #74 The problem is also covered in updated tests.
Of course you can wait for saving by calling `.save()` manually, as proposed in #74 but it seems unreliable and inconcistent, if session can be updated during any request you have to use `.save()` anywhere. 
My solution may be not very nice, haven't found better way to fix this.