### PR TITLE
Only touch sessions in the store when rolling sessions are enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ always touched in the store at the end of each request. If set to `false`,
 unmodified sessions are only touched when `rolling` is enabled.
 
 The default value is `true`. This means the expiration date in the cookie can
-differ from that in the store when `rolling` is enabled since the cookie
+differ from that in the store when `rolling` is disabled since the cookie
 expiration date is only updated if the session is modified but the session in
 the store is updated regardless.
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ will add an empty Passport object to the session for use after a user is
 authenticated, which will be treated as a modification to the session, causing
 it to be saved. *This has been fixed in PassportJS 0.3.0*
 
+##### alwaysTouchUnmodified
+
+If set to `true` and the store supports "touching", unmodified sessions are
+always touched in the store at the end of each request. If set to `false`,
+unmodified sessions are only touched when `rolling` is enabled.
+
+The default value is `true`. This means the expiration date in the cookie can
+differ from that in the store when `rolling` is enabled since the cookie
+expiration date is only updated if the session is modified but the session in
+the store is updated regardless.
+
 ##### secret
 
 **Required option**

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ var defer = typeof setImmediate === 'function'
  * @param {Boolean} [options.resave] Resave unmodified sessions back to the store
  * @param {Boolean} [options.rolling] Enable/disable rolling session expiration
  * @param {Boolean} [options.saveUninitialized] Save uninitialized sessions to the store
+ * @param {Boolean} [options.alwaysTouchUnmodified] Always touch unmodified sessions
  * @param {String|Array} [options.secret] Secret for signing session ID
  * @param {Object} [options.store=MemoryStore] Session store
  * @param {String} [options.unset]
@@ -110,6 +111,9 @@ function session(options) {
   // get the save uninitialized session option
   var saveUninitializedSession = opts.saveUninitialized
 
+  // get the save uninitialized session option
+  var alwaysTouchUnmodified = opts.alwaysTouchUnmodified
+
   // get the cookie signing secret
   var secret = opts.secret
 
@@ -125,6 +129,10 @@ function session(options) {
   if (saveUninitializedSession === undefined) {
     deprecate('undefined saveUninitialized option; provide saveUninitialized option');
     saveUninitializedSession = true;
+  }
+
+  if (alwaysTouchUnmodified === undefined) {
+    alwaysTouchUnmodified = true;
   }
 
   if (opts.unset && opts.unset !== 'destroy' && opts.unset !== 'keep') {
@@ -336,7 +344,7 @@ function session(options) {
         });
 
         return writetop();
-      } else if (rollingSessions && storeImplementsTouch && shouldTouch(req)) {
+      } else if ((alwaysTouchUnmodified || rollingSessions) && storeImplementsTouch && shouldTouch(req)) {
         // store implements touch method
         debug('touching');
         store.touch(req.sessionID, req.session, function ontouch(err) {

--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ function session(options) {
         });
 
         return writetop();
-      } else if (storeImplementsTouch && shouldTouch(req)) {
+      } else if (rollingSessions && storeImplementsTouch && shouldTouch(req)) {
         // store implements touch method
         debug('touching');
         store.touch(req.sessionID, req.session, function ontouch(err) {

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ function session(options) {
         });
 
         return writetop();
-      } else if ((alwaysTouchUnmodified || rollingSessions) && storeImplementsTouch && shouldTouch(req)) {
+      } else if (storeImplementsTouch && shouldTouch(req)) {
         // store implements touch method
         debug('touching');
         store.touch(req.sessionID, req.session, function ontouch(err) {
@@ -440,7 +440,8 @@ function session(options) {
         return false;
       }
 
-      return cookieId === req.sessionID && !shouldSave(req);
+      return cookieId === req.sessionID && !shouldSave(req) &&
+        (rollingSessions || alwaysTouchUnmodified);
     }
 
     // determine if cookie should be set on response

--- a/test/session.js
+++ b/test/session.js
@@ -1073,7 +1073,7 @@ describe('session()', function(){
     it('should pass session touch error', function (done) {
       var cb = after(2, done)
       var store = new session.MemoryStore()
-      var server = createServer({ store: store, resave: false, rolling: true }, function (req, res) {
+      var server = createServer({ store: store, resave: false }, function (req, res) {
         req.session.hit = true
         res.end('session saved')
       })
@@ -1096,28 +1096,6 @@ describe('session()', function(){
         .get('/')
         .set('Cookie', cookie(res))
         .end(cb)
-      })
-    })
-
-    it('should not touch with bogus req.sessionID', function (done) {
-      var store = new session.MemoryStore()
-      var server = createServer({ store: store, resave: false, rolling: true }, function (req, res) {
-        req.sessionID = function () {}
-        req.session.test1 = 1
-        req.session.test2 = 'b'
-        res.end()
-      })
-
-      request(server)
-      .get('/')
-      .expect(shouldNotHaveHeader('Set-Cookie'))
-      .expect(200, function (err) {
-        if (err) return done(err)
-        store.length(function (err, length) {
-          if (err) return done(err)
-          assert.equal(length, 0)
-          done()
-        })
       })
     })
   });
@@ -1887,7 +1865,7 @@ describe('session()', function(){
     describe('.touch()', function () {
       it('should reset session expiration', function (done) {
         var store = new session.MemoryStore()
-        var server = createServer({ resave: false, rolling: true, store: store, cookie: { maxAge: min } }, function (req, res) {
+        var server = createServer({ resave: false, store: store, cookie: { maxAge: min } }, function (req, res) {
           req.session.hit = true
           req.session.touch()
           res.end()

--- a/test/session.js
+++ b/test/session.js
@@ -1,4 +1,3 @@
-
 process.env.NO_DEPRECATION = 'express-session';
 
 var after = require('after')
@@ -1074,7 +1073,7 @@ describe('session()', function(){
     it('should pass session touch error', function (done) {
       var cb = after(2, done)
       var store = new session.MemoryStore()
-      var server = createServer({ store: store, resave: false }, function (req, res) {
+      var server = createServer({ store: store, resave: false, rolling: true }, function (req, res) {
         req.session.hit = true
         res.end('session saved')
       })
@@ -1702,7 +1701,7 @@ describe('session()', function(){
     describe('.touch()', function () {
       it('should reset session expiration', function (done) {
         var store = new session.MemoryStore()
-        var server = createServer({ resave: false, store: store, cookie: { maxAge: min } }, function (req, res) {
+        var server = createServer({ resave: false, rolling: true, store: store, cookie: { maxAge: min } }, function (req, res) {
           req.session.hit = true
           req.session.touch()
           res.end()

--- a/test/session.js
+++ b/test/session.js
@@ -1211,21 +1211,23 @@ describe('session()', function(){
           if (err) return done(err);
 
           var expires1 = new Date(sess.cookie.expires);
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(shouldSetCookie('connect.sid'))
-          .expect(200, function (err, res) {
-            if (err) return done(err);
+          setTimeout(function () {
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetCookie('connect.sid'))
+              .expect(200, function (err, res) {
+                if (err) return done(err);
 
-            assert.ok(touched);
-            store.get(id, function (err, sess) {
-              if (err) return done(err);
-              var expires2 = new Date(sess.cookie.expires);
-              assert(expires1.getTime() < expires2.getTime());
-              done();
-            });
-          });
+                assert.ok(touched);
+                store.get(id, function (err, sess) {
+                  if (err) return done(err);
+                  var expires2 = new Date(sess.cookie.expires);
+                  assert(expires1.getTime() < expires2.getTime());
+                  done();
+                });
+              });
+          }, 10);
         });
       });
     });
@@ -1252,20 +1254,22 @@ describe('session()', function(){
           if (err) return done(err);
 
           var expires1 = new Date(sess.cookie.expires);
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, function (err, res) {
-            if (err) return done(err);
+          setTimeout(function () {
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, function (err, res) {
+                if (err) return done(err);
 
-            assert.ok(touched);
-            store.get(id, function (err, sess) {
-              if (err) return done(err);
-              var expires2 = new Date(sess.cookie.expires);
-              assert(expires1.getTime() < expires2.getTime());
-              done();
-            });
-          });
+                assert.ok(touched);
+                store.get(id, function (err, sess) {
+                  if (err) return done(err);
+                  var expires2 = new Date(sess.cookie.expires);
+                  assert(expires1.getTime() < expires2.getTime());
+                  done();
+                });
+              });
+          }, 10);
         });
       });
     });
@@ -1292,21 +1296,23 @@ describe('session()', function(){
           if (err) return done(err);
 
           var expires1 = new Date(sess.cookie.expires);
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(shouldSetCookie('connect.sid'))
-          .expect(200, function (err, res) {
-            if (err) return done(err);
+          setTimeout(function () {
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetCookie('connect.sid'))
+              .expect(200, function (err, res) {
+                if (err) return done(err);
 
-            assert.ok(touched);
-            store.get(id, function (err, sess) {
-              if (err) return done(err);
-              var expires2 = new Date(sess.cookie.expires);
-              assert(expires1.getTime() < expires2.getTime());
-              done();
-            });
-          });
+                assert.ok(touched);
+                store.get(id, function (err, sess) {
+                  if (err) return done(err);
+                  var expires2 = new Date(sess.cookie.expires);
+                  assert(expires1.getTime() < expires2.getTime());
+                  done();
+                });
+              });
+          }, 10);
         });
       });
     });
@@ -1333,20 +1339,22 @@ describe('session()', function(){
           if (err) return done(err);
 
           var expires1 = new Date(sess.cookie.expires);
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, function (err, res) {
-            if (err) return done(err);
+          setTimeout(function () {
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, function (err, res) {
+                if (err) return done(err);
 
-            assert.ok(!touched);
-            store.get(id, function (err, sess) {
-              if (err) return done(err);
-              var expires2 = new Date(sess.cookie.expires);
-              assert.equal(expires1.getTime(), expires2.getTime());
-              done();
-            });
-          });
+                assert.ok(!touched);
+                store.get(id, function (err, sess) {
+                  if (err) return done(err);
+                  var expires2 = new Date(sess.cookie.expires);
+                  assert.equal(expires1.getTime(), expires2.getTime());
+                  done();
+                });
+              });
+          }, 10);
         });
       });
     });

--- a/test/session.js
+++ b/test/session.js
@@ -963,6 +963,88 @@ describe('session()', function(){
       .expect(shouldSetCookie('connect.sid'))
       .expect(200, done);
     });
+
+    it('should touch unmodified sessions when set', function(done){
+      var store = new session.MemoryStore()
+      var server = createServer({ store: store, resave: false, rolling: true, saveUninitialized: true })
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function(err, res){
+        if (err) return done(err);
+
+        var touched = false
+        var _touch = store.touch;
+        store.touch = function touch(sid, sess, callback) {
+          touched = true;
+          _touch.call(store, sid, sess, callback);
+        }
+
+        var id = sid(res)
+        store.get(id, function (err, sess) {
+          if (err) return done(err);
+
+          var expires1 = new Date(sess.cookie.expires);
+          request(server)
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, function (err, res) {
+            if (err) return done(err);
+
+            assert.ok(touched);
+            store.get(id, function (err, sess) {
+              if (err) return done(err);
+              var expires2 = new Date(sess.cookie.expires);
+              assert(expires1.getTime() < expires2.getTime());
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('should not touch unmodified sessions when unset', function(done){
+      var store = new session.MemoryStore()
+      var server = createServer({ store: store, resave: false, rolling: false, saveUninitialized: true })
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function(err, res){
+        if (err) return done(err);
+
+        var touched = false
+        var _touch = store.touch;
+        store.touch = function touch(sid, sess, callback) {
+          touched = true;
+          _touch.call(store, sid, sess, callback);
+        }
+
+        var id = sid(res)
+        store.get(id, function (err, sess) {
+          if (err) return done(err);
+
+          var expires1 = new Date(sess.cookie.expires);
+          request(server)
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, function (err, res) {
+            if (err) return done(err);
+
+            assert.ok(!touched);
+            store.get(id, function (err, sess) {
+              if (err) return done(err);
+              var expires2 = new Date(sess.cookie.expires);
+              assert.equal(expires1.getTime(), expires2.getTime());
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 
   describe('resave option', function(){

--- a/test/session.js
+++ b/test/session.js
@@ -1098,6 +1098,28 @@ describe('session()', function(){
         .end(cb)
       })
     })
+
+    it('should not touch with bogus req.sessionID', function (done) {
+      var store = new session.MemoryStore()
+      var server = createServer({ store: store, resave: false, rolling: true }, function (req, res) {
+        req.sessionID = function () {}
+        req.session.test1 = 1
+        req.session.test2 = 'b'
+        res.end()
+      })
+
+      request(server)
+      .get('/')
+      .expect(shouldNotHaveHeader('Set-Cookie'))
+      .expect(200, function (err) {
+        if (err) return done(err)
+        store.length(function (err, length) {
+          if (err) return done(err)
+          assert.equal(length, 0)
+          done()
+        })
+      })
+    })
   });
 
   describe('saveUninitialized option', function(){


### PR DESCRIPTION
- Currently, disabling rolling sessions suppresses unmodified
  cookies being sent back to the client (line 447). However, the
  session is "touched" in the store regardless of whether rolling
  sessions are enabled (line 339).

- This results in the expiry time in the cookie and in the
  persistent session deviating. Specifically, the expiry of the
  persistent session is pushed back on each and every request
  whereas the cookie expiry is only updated if the request
  changes the session.

- This prevents the use case of a "session ping" request that is
  sent by the client to test if their session is still valid. We
  have achieved this by turning off rolling sessions and placing
  the handling of the ping early in the express stack. A stack
  entry is then placed after the ping handling to make a benign
  change to the session to cause it to be stored, in effect,
  touching the session much like rolling sessions. An example
  router might look like (using passport with disabled rolling
  sessions):

```javascript
    router.get('/ping', function (req, res, next) {
        if (!req.isAuthenticated()) {
            res.sendStatus(403);
        }
        else {
            res.sendStatus(200);
        }
    });

    router.use(function (req, res, next) {
        // Push back session expiry and make benign change to
        // force persistent storage.
        req.session.cookie.maxAge = 3600;
        req.session._dummy = req.session._dummy ? (req.session._dummy + 1) : 1;
        next();
    });
```

- This appears to work from a client perspective as the cookie
  expires at the appropriate time. However, the session expiry
  in the store is always pushed back, even for ping requests.
  This means that from a server perspective the session is
  still valid for some period after the cookie expiry. The
  store expiry therefore cannot be trusted or used to identify
  expired sessions in the store for purging or clean up.
