### PR TITLE
fix getcookie cookie fallbacks for signed vs unsigned

### DIFF
--- a/index.js
+++ b/index.js
@@ -536,16 +536,7 @@ function getcookie(req, name, secrets) {
 
   // back-compat read from cookieParser() signedCookies data
   if (!val && req.signedCookies) {
-    val = req.signedCookies[name];
-
-    if (val) {
-      deprecate('cookie should be available in req.headers.cookie');
-    }
-  }
-
-  // back-compat read from cookieParser() cookies data
-  if (!val && req.cookies) {
-    raw = req.cookies[name];
+    raw = req.signedCookies[name];
 
     if (raw) {
       if (raw.substr(0, 2) === 's:') {
@@ -562,6 +553,15 @@ function getcookie(req, name, secrets) {
       } else {
         debug('cookie unsigned')
       }
+    }
+  }
+
+  // back-compat read from cookieParser() cookies data
+  if (!val && req.cookies) {
+    val = req.cookies[name];
+
+    if (val) {
+      deprecate('cookie should be available in req.headers.cookie');
     }
   }
 


### PR DESCRIPTION
It seems to me that the fallbacks for retrieving cookies for signed and unsigned cookies are implemented the wrong way around. I'm guessing that this code doesn't get executed much since these are fallbacks only triggered when cookies are not available in headers. The reason the fallbacks are necessary in my project is because I'm using express session with sockets via https://github.com/oskosk/express-socket.io-session which stores the cookies in the req.