### PR TITLE
Added fix for maxAge string unhandled type error

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Catch invalid `cookie.maxAge` value earlier
   * Fix issue where `resave: false` may not save altered sessions
   * Use `safe-buffer` for improved Buffer API
   * Use `Set-Cookie` as cookie header name for compatibility

--- a/session/cookie.js
+++ b/session/cookie.js
@@ -77,6 +77,10 @@ Cookie.prototype = {
    */
 
   set maxAge(ms) {
+    if (ms && typeof ms !== 'number' && !(ms instanceof Date)) {
+      throw new TypeError('maxAge must be a number or Date')
+    }
+
     this.expires = 'number' == typeof ms
       ? new Date(Date.now() + ms)
       : ms;

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -93,6 +93,12 @@ describe('new Cookie()', function () {
         assert.ok(maxAge.getTime() - Date.now() - 1000 <= cookie.maxAge)
         assert.ok(maxAge.getTime() - Date.now() + 1000 >= cookie.maxAge)
       })
+
+      it('should reject invalid types', function() {
+        assert.throws(function() { new Cookie({ maxAge: '42' }) }, /maxAge/)
+        assert.throws(function() { new Cookie({ maxAge: true }) }, /maxAge/)
+        assert.throws(function() { new Cookie({ maxAge: function () {} }) }, /maxAge/)
+      })
     })
 
     describe('path', function () {


### PR DESCRIPTION
This solves #432. I'm setting the `maxAge` with an environment variable which is parsed as a string. The PR adds a small fix to automatically convert strings to integers, as the error message is vague and creates confusion.