### PR TITLE
Create and apply eslint rule for semicolon enforcement

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,3 +5,4 @@ rules:
   no-mixed-spaces-and-tabs: error
   no-trailing-spaces: error
   one-var: ["error", { "initialized": "never" }]
+  semi: 1

--- a/index.js
+++ b/index.js
@@ -13,20 +13,20 @@
  * @private
  */
 
-var Buffer = require('safe-buffer').Buffer
+var Buffer = require('safe-buffer').Buffer;
 var cookie = require('cookie');
-var crypto = require('crypto')
+var crypto = require('crypto');
 var debug = require('debug')('express-session');
 var deprecate = require('depd')('express-session');
-var onHeaders = require('on-headers')
+var onHeaders = require('on-headers');
 var parseUrl = require('parseurl');
-var signature = require('cookie-signature')
-var uid = require('uid-safe').sync
+var signature = require('cookie-signature');
+var uid = require('uid-safe').sync;
 
-var Cookie = require('./session/cookie')
-var MemoryStore = require('./session/memory')
-var Session = require('./session/session')
-var Store = require('./session/store')
+var Cookie = require('./session/cookie');
+var MemoryStore = require('./session/memory');
+var Session = require('./session/session');
+var Store = require('./session/store');
 
 // environment
 
@@ -64,7 +64,7 @@ var warning = 'Warning: connect.session() MemoryStore is not\n'
 /* istanbul ignore next */
 var defer = typeof setImmediate === 'function'
   ? setImmediate
-  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
+  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)); };
 
 /**
  * Setup session store with the given `options`.
@@ -85,34 +85,34 @@ var defer = typeof setImmediate === 'function'
  */
 
 function session(options) {
-  var opts = options || {}
+  var opts = options || {};
 
   // get the cookie options
-  var cookieOptions = opts.cookie || {}
+  var cookieOptions = opts.cookie || {};
 
   // get the session id generate function
-  var generateId = opts.genid || generateSessionId
+  var generateId = opts.genid || generateSessionId;
 
   // get the session cookie name
-  var name = opts.name || opts.key || 'connect.sid'
+  var name = opts.name || opts.key || 'connect.sid';
 
   // get the session store
-  var store = opts.store || new MemoryStore()
+  var store = opts.store || new MemoryStore();
 
   // get the trust proxy setting
-  var trustProxy = opts.proxy
+  var trustProxy = opts.proxy;
 
   // get the resave session option
   var resaveSession = opts.resave;
 
   // get the rolling session option
-  var rollingSessions = Boolean(opts.rolling)
+  var rollingSessions = Boolean(opts.rolling);
 
   // get the save uninitialized session option
-  var saveUninitializedSession = opts.saveUninitialized
+  var saveUninitializedSession = opts.saveUninitialized;
 
   // get the cookie signing secret
-  var secret = opts.secret
+  var secret = opts.secret;
 
   if (typeof generateId !== 'function') {
     throw new TypeError('genid option must be a function');
@@ -133,7 +133,7 @@ function session(options) {
   }
 
   // TODO: switch to "destroy" on next major
-  var unsetDestroy = opts.unset === 'destroy'
+  var unsetDestroy = opts.unset === 'destroy';
 
   if (Array.isArray(secret) && secret.length === 0) {
     throw new TypeError('secret option array must contain one or more strings');
@@ -168,31 +168,31 @@ function session(options) {
   var storeImplementsTouch = typeof store.touch === 'function';
 
   // register event listeners for the store to track readiness
-  var storeReady = true
+  var storeReady = true;
   store.on('disconnect', function ondisconnect() {
-    storeReady = false
-  })
+    storeReady = false;
+  });
   store.on('connect', function onconnect() {
-    storeReady = true
-  })
+    storeReady = true;
+  });
 
   return function session(req, res, next) {
     // self-awareness
     if (req.session) {
-      next()
-      return
+      next();
+      return;
     }
 
     // Handle connection as if there is no session if
     // the store has temporarily disconnected etc
     if (!storeReady) {
-      debug('store is disconnected')
-      next()
-      return
+      debug('store is disconnected');
+      next();
+      return;
     }
 
     // pathname mismatch
-    var originalPath = parseUrl.original(req).pathname || '/'
+    var originalPath = parseUrl.original(req).pathname || '/';
     if (originalPath.indexOf(cookieOptions.path || '/') !== 0) return next();
 
     // ensure a secret is available or bail
@@ -208,7 +208,7 @@ function session(options) {
     var originalHash;
     var originalId;
     var savedHash;
-    var touched = false
+    var touched = false;
 
     // expose store
     req.sessionStore = store;
@@ -235,8 +235,8 @@ function session(options) {
 
       if (!touched) {
         // touch session
-        req.session.touch()
-        touched = true
+        req.session.touch();
+        touched = true;
       }
 
       // set cookie
@@ -323,8 +323,8 @@ function session(options) {
 
       if (!touched) {
         // touch session
-        req.session.touch()
-        touched = true
+        req.session.touch();
+        touched = true;
       }
 
       if (shouldSave(req)) {
@@ -365,15 +365,15 @@ function session(options) {
 
     // wrap session methods
     function wrapmethods(sess) {
-      var _reload = sess.reload
+      var _reload = sess.reload;
       var _save = sess.save;
 
       function reload(callback) {
-        debug('reloading %s', this.id)
+        debug('reloading %s', this.id);
         _reload.call(this, function () {
-          wrapmethods(req.session)
-          callback.apply(this, arguments)
-        })
+          wrapmethods(req.session);
+          callback.apply(this, arguments);
+        });
       }
 
       function save() {
@@ -387,7 +387,7 @@ function session(options) {
         enumerable: false,
         value: reload,
         writable: true
-      })
+      });
 
       Object.defineProperty(sess, 'save', {
         configurable: true,
@@ -422,7 +422,7 @@ function session(options) {
 
       return !saveUninitializedSession && cookieId !== req.sessionID
         ? isModified(req.session)
-        : !isSaved(req.session)
+        : !isSaved(req.session);
     }
 
     // determine if session should be touched
@@ -481,7 +481,7 @@ function session(options) {
         originalHash = hash(sess);
 
         if (!resaveSession) {
-          savedHash = originalHash
+          savedHash = originalHash;
         }
 
         wrapmethods(req.session);
@@ -530,7 +530,7 @@ function getcookie(req, name, secrets) {
           val = undefined;
         }
       } else {
-        debug('cookie unsigned')
+        debug('cookie unsigned');
       }
     }
   }
@@ -561,7 +561,7 @@ function getcookie(req, name, secrets) {
           val = undefined;
         }
       } else {
-        debug('cookie unsigned')
+        debug('cookie unsigned');
       }
     }
   }
@@ -582,17 +582,17 @@ function hash(sess) {
   var str = JSON.stringify(sess, function (key, val) {
     // ignore sess.cookie property
     if (this === sess && key === 'cookie') {
-      return
+      return;
     }
 
-    return val
-  })
+    return val;
+  });
 
   // hash
   return crypto
     .createHash('sha1')
     .update(str, 'utf8')
-    .digest('hex')
+    .digest('hex');
 }
 
 /**
@@ -617,7 +617,7 @@ function issecure(req, trustProxy) {
 
   // no explicit trust; try req.secure from express
   if (trustProxy !== true) {
-    return req.secure === true
+    return req.secure === true;
   }
 
   // read the proto from x-forwarded-proto header
@@ -625,7 +625,7 @@ function issecure(req, trustProxy) {
   var index = header.indexOf(',');
   var proto = index !== -1
     ? header.substr(0, index).toLowerCase().trim()
-    : header.toLowerCase().trim()
+    : header.toLowerCase().trim();
 
   return proto === 'https';
 }
@@ -642,10 +642,10 @@ function setcookie(res, name, val, secret, options) {
 
   debug('set-cookie %s', data);
 
-  var prev = res.getHeader('Set-Cookie') || []
+  var prev = res.getHeader('Set-Cookie') || [];
   var header = Array.isArray(prev) ? prev.concat(data) : [prev, data];
 
-  res.setHeader('Set-Cookie', header)
+  res.setHeader('Set-Cookie', header);
 }
 
 /**

--- a/session/cookie.js
+++ b/session/cookie.js
@@ -11,8 +11,8 @@
  * Module dependencies.
  */
 
-var cookie = require('cookie')
-var deprecate = require('depd')('express-session')
+var cookie = require('cookie');
+var deprecate = require('depd')('express-session');
 
 /**
  * Initialize a new `Cookie` with the given `options`.
@@ -29,11 +29,11 @@ var Cookie = module.exports = function Cookie(options) {
 
   if (options) {
     if (typeof options !== 'object') {
-      throw new TypeError('argument options must be a object')
+      throw new TypeError('argument options must be a object');
     }
 
     for (var key in options) {
-      this[key] = options[key]
+      this[key] = options[key];
     }
   }
 
@@ -80,11 +80,11 @@ Cookie.prototype = {
 
   set maxAge(ms) {
     if (ms && typeof ms !== 'number' && !(ms instanceof Date)) {
-      throw new TypeError('maxAge must be a number or Date')
+      throw new TypeError('maxAge must be a number or Date');
     }
 
     if (ms instanceof Date) {
-      deprecate('maxAge as Date; pass number of milliseconds instead')
+      deprecate('maxAge as Date; pass number of milliseconds instead');
     }
 
     this.expires = 'number' == typeof ms
@@ -121,7 +121,7 @@ Cookie.prototype = {
       , domain: this.domain
       , path: this.path
       , sameSite: this.sameSite
-    }
+    };
   },
 
   /**

--- a/session/memory.js
+++ b/session/memory.js
@@ -13,8 +13,8 @@
  * @private
  */
 
-var Store = require('./store')
-var util = require('util')
+var Store = require('./store');
+var util = require('util');
 
 /**
  * Shim setImmediate for node.js < 0.10
@@ -24,13 +24,13 @@ var util = require('util')
 /* istanbul ignore next */
 var defer = typeof setImmediate === 'function'
   ? setImmediate
-  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
+  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)); };
 
 /**
  * Module exports.
  */
 
-module.exports = MemoryStore
+module.exports = MemoryStore;
 
 /**
  * A session store in memory.
@@ -38,15 +38,15 @@ module.exports = MemoryStore
  */
 
 function MemoryStore() {
-  Store.call(this)
-  this.sessions = Object.create(null)
+  Store.call(this);
+  this.sessions = Object.create(null);
 }
 
 /**
  * Inherit from Store.
  */
 
-util.inherits(MemoryStore, Store)
+util.inherits(MemoryStore, Store);
 
 /**
  * Get all active sessions.
@@ -56,20 +56,20 @@ util.inherits(MemoryStore, Store)
  */
 
 MemoryStore.prototype.all = function all(callback) {
-  var sessionIds = Object.keys(this.sessions)
-  var sessions = Object.create(null)
+  var sessionIds = Object.keys(this.sessions);
+  var sessions = Object.create(null);
 
   for (var i = 0; i < sessionIds.length; i++) {
-    var sessionId = sessionIds[i]
-    var session = getSession.call(this, sessionId)
+    var sessionId = sessionIds[i];
+    var session = getSession.call(this, sessionId);
 
     if (session) {
       sessions[sessionId] = session;
     }
   }
 
-  callback && defer(callback, null, sessions)
-}
+  callback && defer(callback, null, sessions);
+};
 
 /**
  * Clear all sessions.
@@ -79,9 +79,9 @@ MemoryStore.prototype.all = function all(callback) {
  */
 
 MemoryStore.prototype.clear = function clear(callback) {
-  this.sessions = Object.create(null)
-  callback && defer(callback)
-}
+  this.sessions = Object.create(null);
+  callback && defer(callback);
+};
 
 /**
  * Destroy the session associated with the given session ID.
@@ -91,9 +91,9 @@ MemoryStore.prototype.clear = function clear(callback) {
  */
 
 MemoryStore.prototype.destroy = function destroy(sessionId, callback) {
-  delete this.sessions[sessionId]
-  callback && defer(callback)
-}
+  delete this.sessions[sessionId];
+  callback && defer(callback);
+};
 
 /**
  * Fetch session by the given session ID.
@@ -104,8 +104,8 @@ MemoryStore.prototype.destroy = function destroy(sessionId, callback) {
  */
 
 MemoryStore.prototype.get = function get(sessionId, callback) {
-  defer(callback, null, getSession.call(this, sessionId))
-}
+  defer(callback, null, getSession.call(this, sessionId));
+};
 
 /**
  * Commit the given session associated with the given sessionId to the store.
@@ -117,9 +117,9 @@ MemoryStore.prototype.get = function get(sessionId, callback) {
  */
 
 MemoryStore.prototype.set = function set(sessionId, session, callback) {
-  this.sessions[sessionId] = JSON.stringify(session)
-  callback && defer(callback)
-}
+  this.sessions[sessionId] = JSON.stringify(session);
+  callback && defer(callback);
+};
 
 /**
  * Get number of active sessions.
@@ -130,10 +130,10 @@ MemoryStore.prototype.set = function set(sessionId, session, callback) {
 
 MemoryStore.prototype.length = function length(callback) {
   this.all(function (err, sessions) {
-    if (err) return callback(err)
-    callback(null, Object.keys(sessions).length)
-  })
-}
+    if (err) return callback(err);
+    callback(null, Object.keys(sessions).length);
+  });
+};
 
 /**
  * Touch the given session object associated with the given session ID.
@@ -145,16 +145,16 @@ MemoryStore.prototype.length = function length(callback) {
  */
 
 MemoryStore.prototype.touch = function touch(sessionId, session, callback) {
-  var currentSession = getSession.call(this, sessionId)
+  var currentSession = getSession.call(this, sessionId);
 
   if (currentSession) {
     // update expiration
-    currentSession.cookie = session.cookie
-    this.sessions[sessionId] = JSON.stringify(currentSession)
+    currentSession.cookie = session.cookie;
+    this.sessions[sessionId] = JSON.stringify(currentSession);
   }
 
-  callback && defer(callback)
-}
+  callback && defer(callback);
+};
 
 /**
  * Get session from the store.
@@ -162,24 +162,24 @@ MemoryStore.prototype.touch = function touch(sessionId, session, callback) {
  */
 
 function getSession(sessionId) {
-  var sess = this.sessions[sessionId]
+  var sess = this.sessions[sessionId];
 
   if (!sess) {
-    return
+    return;
   }
 
   // parse
-  sess = JSON.parse(sess)
+  sess = JSON.parse(sess);
 
   var expires = typeof sess.cookie.expires === 'string'
     ? new Date(sess.cookie.expires)
-    : sess.cookie.expires
+    : sess.cookie.expires;
 
   // destroy expired session
   if (expires && expires <= Date.now()) {
-    delete this.sessions[sessionId]
-    return
+    delete this.sessions[sessionId];
+    return;
   }
 
-  return sess
+  return sess;
 }

--- a/session/session.js
+++ b/session/session.js
@@ -29,7 +29,7 @@ function Session(req, data) {
     // merge data into this, ignoring prototype properties
     for (var prop in data) {
       if (!(prop in this)) {
-        this[prop] = data[prop]
+        this[prop] = data[prop];
       }
     }
   }
@@ -86,8 +86,8 @@ defineMethod(Session.prototype, 'save', function save(fn) {
  */
 
 defineMethod(Session.prototype, 'reload', function reload(fn) {
-  var req = this.req
-  var store = this.req.sessionStore
+  var req = this.req;
+  var store = this.req.sessionStore;
 
   store.get(this.id, function(err, sess){
     if (err) return fn(err);

--- a/session/store.js
+++ b/session/store.js
@@ -12,17 +12,17 @@
  * @private
  */
 
-var Cookie = require('./cookie')
-var EventEmitter = require('events').EventEmitter
-var Session = require('./session')
-var util = require('util')
+var Cookie = require('./cookie');
+var EventEmitter = require('events').EventEmitter;
+var Session = require('./session');
+var util = require('util');
 
 /**
  * Module exports.
  * @public
  */
 
-module.exports = Store
+module.exports = Store;
 
 /**
  * Abstract base class for session stores.
@@ -30,14 +30,14 @@ module.exports = Store
  */
 
 function Store () {
-  EventEmitter.call(this)
+  EventEmitter.call(this);
 }
 
 /**
  * Inherit from EventEmitter.
  */
 
-util.inherits(Store, EventEmitter)
+util.inherits(Store, EventEmitter);
 
 /**
  * Re-generate the given requests's session.
@@ -70,7 +70,7 @@ Store.prototype.load = function(sid, fn){
     if (err) return fn(err);
     if (!sess) return fn();
     var req = { sessionID: sid, sessionStore: self };
-    fn(null, self.createSession(req, sess))
+    fn(null, self.createSession(req, sess));
   });
 };
 
@@ -84,8 +84,8 @@ Store.prototype.load = function(sid, fn){
  */
 
 Store.prototype.createSession = function(req, sess){
-  var expires = sess.cookie.expires
-  var orig = sess.cookie.originalMaxAge
+  var expires = sess.cookie.expires;
+  var orig = sess.cookie.originalMaxAge;
 
   sess.cookie = new Cookie(sess.cookie);
   if ('string' == typeof expires) sess.cookie.expires = new Date(expires);

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -1,112 +1,112 @@
 
-var assert = require('assert')
-var Cookie = require('../session/cookie')
+var assert = require('assert');
+var Cookie = require('../session/cookie');
 
 describe('new Cookie()', function () {
   it('should create a new cookie object', function () {
-    assert.strictEqual(typeof new Cookie(), 'object')
-  })
+    assert.strictEqual(typeof new Cookie(), 'object');
+  });
 
   it('should default expires to null', function () {
-    var cookie = new Cookie()
-    assert.strictEqual(cookie.expires, null)
-  })
+    var cookie = new Cookie();
+    assert.strictEqual(cookie.expires, null);
+  });
 
   it('should default maxAge to null', function () {
-    var cookie = new Cookie()
-    assert.strictEqual(cookie.maxAge, null)
-  })
+    var cookie = new Cookie();
+    assert.strictEqual(cookie.maxAge, null);
+  });
 
   it('should default httpOnly to true', function () {
-    var cookie = new Cookie()
-    assert.strictEqual(cookie.httpOnly, true)
-  })
+    var cookie = new Cookie();
+    assert.strictEqual(cookie.httpOnly, true);
+  });
 
   it('should default path to "/"', function () {
-    var cookie = new Cookie()
-    assert.strictEqual(cookie.path, '/')
-  })
+    var cookie = new Cookie();
+    assert.strictEqual(cookie.path, '/');
+  });
 
   it('should default maxAge to null', function () {
-    var cookie = new Cookie()
-    assert.strictEqual(cookie.maxAge, null)
-  })
+    var cookie = new Cookie();
+    assert.strictEqual(cookie.maxAge, null);
+  });
 
   describe('with options', function () {
     it('should create a new cookie object', function () {
-      assert.strictEqual(typeof new Cookie({}), 'object')
-    })
+      assert.strictEqual(typeof new Cookie({}), 'object');
+    });
 
     it('should reject non-objects', function () {
-      assert.throws(function () { new Cookie(42) }, /argument options/)
-      assert.throws(function () { new Cookie('foo') }, /argument options/)
-      assert.throws(function () { new Cookie(true) }, /argument options/)
-      assert.throws(function () { new Cookie(function () {}) }, /argument options/)
-    })
+      assert.throws(function () { new Cookie(42); }, /argument options/);
+      assert.throws(function () { new Cookie('foo'); }, /argument options/);
+      assert.throws(function () { new Cookie(true); }, /argument options/);
+      assert.throws(function () { new Cookie(function () {}); }, /argument options/);
+    });
 
     describe('expires', function () {
       it('should set expires', function () {
-        var expires = new Date(Date.now() + 60000)
-        var cookie = new Cookie({ expires: expires })
+        var expires = new Date(Date.now() + 60000);
+        var cookie = new Cookie({ expires: expires });
 
-        assert.strictEqual(cookie.expires, expires)
-      })
+        assert.strictEqual(cookie.expires, expires);
+      });
 
       it('should set maxAge', function () {
-        var expires = new Date(Date.now() + 60000)
-        var cookie = new Cookie({ expires: expires })
+        var expires = new Date(Date.now() + 60000);
+        var cookie = new Cookie({ expires: expires });
 
-        assert.ok(expires.getTime() - Date.now() - 1000 <= cookie.maxAge)
-        assert.ok(expires.getTime() - Date.now() + 1000 >= cookie.maxAge)
-      })
-    })
+        assert.ok(expires.getTime() - Date.now() - 1000 <= cookie.maxAge);
+        assert.ok(expires.getTime() - Date.now() + 1000 >= cookie.maxAge);
+      });
+    });
 
     describe('httpOnly', function () {
       it('should set httpOnly', function () {
-        var cookie = new Cookie({ httpOnly: false })
+        var cookie = new Cookie({ httpOnly: false });
 
-        assert.strictEqual(cookie.httpOnly, false)
-      })
-    })
+        assert.strictEqual(cookie.httpOnly, false);
+      });
+    });
 
     describe('maxAge', function () {
       it('should set expires', function () {
-        var maxAge = 60000
-        var cookie = new Cookie({ maxAge: maxAge })
+        var maxAge = 60000;
+        var cookie = new Cookie({ maxAge: maxAge });
 
-        assert.ok(cookie.expires.getTime() - Date.now() - 1000 <= maxAge)
-        assert.ok(cookie.expires.getTime() - Date.now() + 1000 >= maxAge)
-      })
+        assert.ok(cookie.expires.getTime() - Date.now() - 1000 <= maxAge);
+        assert.ok(cookie.expires.getTime() - Date.now() + 1000 >= maxAge);
+      });
 
       it('should set maxAge', function () {
-        var maxAge = 60000
-        var cookie = new Cookie({ maxAge: maxAge })
+        var maxAge = 60000;
+        var cookie = new Cookie({ maxAge: maxAge });
 
-        assert.strictEqual(cookie.maxAge, maxAge)
-      })
+        assert.strictEqual(cookie.maxAge, maxAge);
+      });
 
       it('should accept Date object', function () {
-        var maxAge = new Date(Date.now() + 60000)
-        var cookie = new Cookie({ maxAge: maxAge })
+        var maxAge = new Date(Date.now() + 60000);
+        var cookie = new Cookie({ maxAge: maxAge });
 
-        assert.strictEqual(cookie.expires.getTime(), maxAge.getTime())
-        assert.ok(maxAge.getTime() - Date.now() - 1000 <= cookie.maxAge)
-        assert.ok(maxAge.getTime() - Date.now() + 1000 >= cookie.maxAge)
-      })
+        assert.strictEqual(cookie.expires.getTime(), maxAge.getTime());
+        assert.ok(maxAge.getTime() - Date.now() - 1000 <= cookie.maxAge);
+        assert.ok(maxAge.getTime() - Date.now() + 1000 >= cookie.maxAge);
+      });
 
       it('should reject invalid types', function() {
-        assert.throws(function() { new Cookie({ maxAge: '42' }) }, /maxAge/)
-        assert.throws(function() { new Cookie({ maxAge: true }) }, /maxAge/)
-        assert.throws(function() { new Cookie({ maxAge: function () {} }) }, /maxAge/)
-      })
-    })
+        assert.throws(function() { new Cookie({ maxAge: '42' }); }, /maxAge/);
+        assert.throws(function() { new Cookie({ maxAge: true }); }, /maxAge/);
+        assert.throws(function() { new Cookie({ maxAge: function () {} }); }, /maxAge/);
+      });
+    });
 
     describe('path', function () {
       it('should set path', function () {
-        var cookie = new Cookie({ path: '/foo' })
+        var cookie = new Cookie({ path: '/foo' });
 
-        assert.strictEqual(cookie.path, '/foo')
-      })
-    })
-  })
-})
+        assert.strictEqual(cookie.path, '/foo');
+      });
+    });
+  });
+});

--- a/test/session.js
+++ b/test/session.js
@@ -1,1223 +1,1223 @@
 
-var after = require('after')
-var assert = require('assert')
-var cookieParser = require('cookie-parser')
-var express = require('express')
-var fs = require('fs')
-var http = require('http')
-var https = require('https')
-var request = require('supertest')
-var session = require('../')
-var util = require('util')
+var after = require('after');
+var assert = require('assert');
+var cookieParser = require('cookie-parser');
+var express = require('express');
+var fs = require('fs');
+var http = require('http');
+var https = require('https');
+var request = require('supertest');
+var session = require('../');
+var util = require('util');
 
-var Cookie = require('../session/cookie')
+var Cookie = require('../session/cookie');
 
 var min = 60 * 1000;
 
 describe('session()', function(){
   it('should export constructors', function(){
-    assert.strictEqual(typeof session.Session, 'function')
-    assert.strictEqual(typeof session.Store, 'function')
-    assert.strictEqual(typeof session.MemoryStore, 'function')
-  })
+    assert.strictEqual(typeof session.Session, 'function');
+    assert.strictEqual(typeof session.Store, 'function');
+    assert.strictEqual(typeof session.MemoryStore, 'function');
+  });
 
   it('should do nothing if req.session exists', function(done){
     function setup (req) {
-      req.session = {}
+      req.session = {};
     }
 
     request(createServer(setup))
-    .get('/')
-    .expect(shouldNotHaveHeader('Set-Cookie'))
-    .expect(200, done)
-  })
+      .get('/')
+      .expect(shouldNotHaveHeader('Set-Cookie'))
+      .expect(200, done);
+  });
 
   it('should error without secret', function(done){
     request(createServer({ secret: undefined }))
-    .get('/')
-    .expect(500, /secret.*required/, done)
-  })
+      .get('/')
+      .expect(500, /secret.*required/, done);
+  });
 
   it('should get secret from req.secret', function(done){
     function setup (req) {
-      req.secret = 'keyboard cat'
+      req.secret = 'keyboard cat';
     }
 
     request(createServer(setup, { secret: undefined }))
-    .get('/')
-    .expect(200, '', done)
-  })
+      .get('/')
+      .expect(200, '', done);
+  });
 
   it('should create a new session', function (done) {
-    var store = new session.MemoryStore()
+    var store = new session.MemoryStore();
     var server = createServer({ store: store }, function (req, res) {
-      req.session.active = true
-      res.end('session active')
+      req.session.active = true;
+      res.end('session active');
     });
 
     request(server)
-    .get('/')
-    .expect(shouldSetCookie('connect.sid'))
-    .expect(200, 'session active', function (err, res) {
-      if (err) return done(err)
-      store.length(function (err, len) {
-        if (err) return done(err)
-        assert.strictEqual(len, 1)
-        done()
-      })
-    })
-  })
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, 'session active', function (err, res) {
+        if (err) return done(err);
+        store.length(function (err, len) {
+          if (err) return done(err);
+          assert.strictEqual(len, 1);
+          done();
+        });
+      });
+  });
 
   it('should load session from cookie sid', function (done) {
-    var count = 0
+    var count = 0;
     var server = createServer(null, function (req, res) {
-      req.session.num = req.session.num || ++count
-      res.end('session ' + req.session.num)
+      req.session.num = req.session.num || ++count;
+      res.end('session ' + req.session.num);
     });
 
     request(server)
-    .get('/')
-    .expect(shouldSetCookie('connect.sid'))
-    .expect(200, 'session 1', function (err, res) {
-      if (err) return done(err)
-      request(server)
       .get('/')
-      .set('Cookie', cookie(res))
-      .expect(200, 'session 1', done)
-    })
-  })
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, 'session 1', function (err, res) {
+        if (err) return done(err);
+        request(server)
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(200, 'session 1', done);
+      });
+  });
 
   it('should pass session fetch error', function (done) {
-    var store = new session.MemoryStore()
+    var store = new session.MemoryStore();
     var server = createServer({ store: store }, function (req, res) {
-      res.end('hello, world')
-    })
+      res.end('hello, world');
+    });
 
     store.get = function destroy(sid, callback) {
-      callback(new Error('boom!'))
-    }
+      callback(new Error('boom!'));
+    };
 
     request(server)
-    .get('/')
-    .expect(shouldSetCookie('connect.sid'))
-    .expect(200, 'hello, world', function (err, res) {
-      if (err) return done(err)
-      request(server)
       .get('/')
-      .set('Cookie', cookie(res))
-      .expect(500, 'boom!', done)
-    })
-  })
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, 'hello, world', function (err, res) {
+        if (err) return done(err);
+        request(server)
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(500, 'boom!', done);
+      });
+  });
 
   it('should treat ENOENT session fetch error as not found', function (done) {
-    var count = 0
-    var store = new session.MemoryStore()
+    var count = 0;
+    var store = new session.MemoryStore();
     var server = createServer({ store: store }, function (req, res) {
-      req.session.num = req.session.num || ++count
-      res.end('session ' + req.session.num)
-    })
+      req.session.num = req.session.num || ++count;
+      res.end('session ' + req.session.num);
+    });
 
     store.get = function destroy(sid, callback) {
-      var err = new Error('boom!')
-      err.code = 'ENOENT'
-      callback(err)
-    }
+      var err = new Error('boom!');
+      err.code = 'ENOENT';
+      callback(err);
+    };
 
     request(server)
-    .get('/')
-    .expect(shouldSetCookie('connect.sid'))
-    .expect(200, 'session 1', function (err, res) {
-      if (err) return done(err)
-      request(server)
       .get('/')
-      .set('Cookie', cookie(res))
-      .expect(200, 'session 2', done)
-    })
-  })
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, 'session 1', function (err, res) {
+        if (err) return done(err);
+        request(server)
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(200, 'session 2', done);
+      });
+  });
 
   it('should create multiple sessions', function (done) {
-    var cb = after(2, check)
-    var count = 0
-    var store = new session.MemoryStore()
+    var cb = after(2, check);
+    var count = 0;
+    var store = new session.MemoryStore();
     var server = createServer({ store: store }, function (req, res) {
-      var isnew = req.session.num === undefined
-      req.session.num = req.session.num || ++count
-      res.end('session ' + (isnew ? 'created' : 'updated'))
+      var isnew = req.session.num === undefined;
+      req.session.num = req.session.num || ++count;
+      res.end('session ' + (isnew ? 'created' : 'updated'));
     });
 
     function check(err) {
-      if (err) return done(err)
+      if (err) return done(err);
       store.all(function (err, sess) {
-        if (err) return done(err)
-        assert.strictEqual(Object.keys(sess).length, 2)
-        done()
-      })
+        if (err) return done(err);
+        assert.strictEqual(Object.keys(sess).length, 2);
+        done();
+      });
     }
 
     request(server)
-    .get('/')
-    .expect(200, 'session created', cb)
+      .get('/')
+      .expect(200, 'session created', cb);
 
     request(server)
-    .get('/')
-    .expect(200, 'session created', cb)
-  })
+      .get('/')
+      .expect(200, 'session created', cb);
+  });
 
   it('should handle empty req.url', function (done) {
     function setup (req) {
-      req.url = ''
+      req.url = '';
     }
 
     request(createServer(setup))
-    .get('/')
-    .expect(shouldSetCookie('connect.sid'))
-    .expect(200, done)
-  })
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, done);
+  });
 
   it('should handle multiple res.end calls', function(done){
     var server = createServer(null, function (req, res) {
-      res.setHeader('Content-Type', 'text/plain')
-      res.end('Hello, world!')
-      res.end()
-    })
+      res.setHeader('Content-Type', 'text/plain');
+      res.end('Hello, world!');
+      res.end();
+    });
 
     request(server)
-    .get('/')
-    .expect('Content-Type', 'text/plain')
-    .expect(200, 'Hello, world!', done);
-  })
+      .get('/')
+      .expect('Content-Type', 'text/plain')
+      .expect(200, 'Hello, world!', done);
+  });
 
   it('should handle res.end(null) calls', function (done) {
     var server = createServer(null, function (req, res) {
-      res.end(null)
-    })
+      res.end(null);
+    });
 
     request(server)
-    .get('/')
-    .expect(200, '', done)
-  })
+      .get('/')
+      .expect(200, '', done);
+  });
 
   it('should handle reserved properties in storage', function (done) {
-    var count = 0
-    var sid
-    var store = new session.MemoryStore()
+    var count = 0;
+    var sid;
+    var store = new session.MemoryStore();
     var server = createServer({ store: store }, function (req, res) {
-      sid = req.session.id
-      req.session.num = req.session.num || ++count
-      res.end('session saved')
-    })
+      sid = req.session.id;
+      req.session.num = req.session.num || ++count;
+      res.end('session saved');
+    });
 
     request(server)
-    .get('/')
-    .expect(200, 'session saved', function (err, res) {
-      if (err) return done(err)
-      store.get(sid, function (err, sess) {
-        if (err) return done(err)
-        // save is reserved
-        sess.save = 'nope'
-        store.set(sid, sess, function (err) {
-          if (err) return done(err)
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, 'session saved', done)
-        })
-      })
-    })
-  })
+      .get('/')
+      .expect(200, 'session saved', function (err, res) {
+        if (err) return done(err);
+        store.get(sid, function (err, sess) {
+          if (err) return done(err);
+          // save is reserved
+          sess.save = 'nope';
+          store.set(sid, sess, function (err) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, 'session saved', done);
+          });
+        });
+      });
+  });
 
   it('should only have session data enumerable (and cookie)', function (done) {
     var server = createServer(null, function (req, res) {
-      req.session.test1 = 1
-      req.session.test2 = 'b'
-      res.end(Object.keys(req.session).sort().join(','))
-    })
+      req.session.test1 = 1;
+      req.session.test2 = 'b';
+      res.end(Object.keys(req.session).sort().join(','));
+    });
 
     request(server)
-    .get('/')
-    .expect(200, 'cookie,test1,test2', done)
-  })
+      .get('/')
+      .expect(200, 'cookie,test1,test2', done);
+  });
 
   it('should not save with bogus req.sessionID', function (done) {
-    var store = new session.MemoryStore()
+    var store = new session.MemoryStore();
     var server = createServer({ store: store }, function (req, res) {
-      req.sessionID = function () {}
-      req.session.test1 = 1
-      req.session.test2 = 'b'
-      res.end()
-    })
+      req.sessionID = function () {};
+      req.session.test1 = 1;
+      req.session.test2 = 'b';
+      res.end();
+    });
 
     request(server)
-    .get('/')
-    .expect(shouldNotHaveHeader('Set-Cookie'))
-    .expect(200, function (err) {
-      if (err) return done(err)
-      store.length(function (err, length) {
-        if (err) return done(err)
-        assert.strictEqual(length, 0)
-        done()
-      })
-    })
-  })
+      .get('/')
+      .expect(shouldNotHaveHeader('Set-Cookie'))
+      .expect(200, function (err) {
+        if (err) return done(err);
+        store.length(function (err, length) {
+          if (err) return done(err);
+          assert.strictEqual(length, 0);
+          done();
+        });
+      });
+  });
 
   it('should update cookie expiration when slow write', function (done) {
     var server = createServer({ rolling: true }, function (req, res) {
-      req.session.user = 'bob'
-      res.write('hello, ')
+      req.session.user = 'bob';
+      res.write('hello, ');
       setTimeout(function () {
-        res.end('world!')
-      }, 200)
-    })
+        res.end('world!');
+      }, 200);
+    });
 
     request(server)
-    .get('/')
-    .expect(shouldSetCookie('connect.sid'))
-    .expect(200, function (err, res) {
-      if (err) return done(err);
-      var originalExpires = expires(res);
-      setTimeout(function () {
-        request(server)
-        .get('/')
-        .set('Cookie', cookie(res))
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(function (res) { assert.notStrictEqual(originalExpires, expires(res)); })
-        .expect(200, done);
-      }, (1000 - (Date.now() % 1000) + 200));
-    });
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function (err, res) {
+        if (err) return done(err);
+        var originalExpires = expires(res);
+        setTimeout(function () {
+          request(server)
+            .get('/')
+            .set('Cookie', cookie(res))
+            .expect(shouldSetCookie('connect.sid'))
+            .expect(function (res) { assert.notStrictEqual(originalExpires, expires(res)); })
+            .expect(200, done);
+        }, (1000 - (Date.now() % 1000) + 200));
+      });
   });
 
   describe('when response ended', function () {
     it('should have saved session', function (done) {
-      var saved = false
-      var store = new session.MemoryStore()
+      var saved = false;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.hit = true
-        res.end('session saved')
-      })
+        req.session.hit = true;
+        res.end('session saved');
+      });
 
-      var _set = store.set
+      var _set = store.set;
       store.set = function set(sid, sess, callback) {
         setTimeout(function () {
           _set.call(store, sid, sess, function (err) {
-            saved = true
-            callback(err)
-          })
-        }, 200)
-      }
+            saved = true;
+            callback(err);
+          });
+        }, 200);
+      };
 
       request(server)
-      .get('/')
-      .expect(200, 'session saved', function (err) {
-        if (err) return done(err)
-        assert.ok(saved)
-        done()
-      })
-    })
+        .get('/')
+        .expect(200, 'session saved', function (err) {
+          if (err) return done(err);
+          assert.ok(saved);
+          done();
+        });
+    });
 
     it('should have saved session even with empty response', function (done) {
-      var saved = false
-      var store = new session.MemoryStore()
+      var saved = false;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.hit = true
-        res.setHeader('Content-Length', '0')
-        res.end()
-      })
+        req.session.hit = true;
+        res.setHeader('Content-Length', '0');
+        res.end();
+      });
 
-      var _set = store.set
+      var _set = store.set;
       store.set = function set(sid, sess, callback) {
         setTimeout(function () {
           _set.call(store, sid, sess, function (err) {
-            saved = true
-            callback(err)
-          })
-        }, 200)
-      }
+            saved = true;
+            callback(err);
+          });
+        }, 200);
+      };
 
       request(server)
-      .get('/')
-      .expect(200, '', function (err) {
-        if (err) return done(err)
-        assert.ok(saved)
-        done()
-      })
-    })
+        .get('/')
+        .expect(200, '', function (err) {
+          if (err) return done(err);
+          assert.ok(saved);
+          done();
+        });
+    });
 
     it('should have saved session even with multi-write', function (done) {
-      var saved = false
-      var store = new session.MemoryStore()
+      var saved = false;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.hit = true
-        res.setHeader('Content-Length', '12')
-        res.write('hello, ')
-        res.end('world')
-      })
+        req.session.hit = true;
+        res.setHeader('Content-Length', '12');
+        res.write('hello, ');
+        res.end('world');
+      });
 
-      var _set = store.set
+      var _set = store.set;
       store.set = function set(sid, sess, callback) {
         setTimeout(function () {
           _set.call(store, sid, sess, function (err) {
-            saved = true
-            callback(err)
-          })
-        }, 200)
-      }
+            saved = true;
+            callback(err);
+          });
+        }, 200);
+      };
 
       request(server)
-      .get('/')
-      .expect(200, 'hello, world', function (err) {
-        if (err) return done(err)
-        assert.ok(saved)
-        done()
-      })
-    })
+        .get('/')
+        .expect(200, 'hello, world', function (err) {
+          if (err) return done(err);
+          assert.ok(saved);
+          done();
+        });
+    });
 
     it('should have saved session even with non-chunked response', function (done) {
-      var saved = false
-      var store = new session.MemoryStore()
+      var saved = false;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.hit = true
-        res.setHeader('Content-Length', '13')
-        res.end('session saved')
-      })
+        req.session.hit = true;
+        res.setHeader('Content-Length', '13');
+        res.end('session saved');
+      });
 
-      var _set = store.set
+      var _set = store.set;
       store.set = function set(sid, sess, callback) {
         setTimeout(function () {
           _set.call(store, sid, sess, function (err) {
-            saved = true
-            callback(err)
-          })
-        }, 200)
-      }
+            saved = true;
+            callback(err);
+          });
+        }, 200);
+      };
 
       request(server)
-      .get('/')
-      .expect(200, 'session saved', function (err) {
-        if (err) return done(err)
-        assert.ok(saved)
-        done()
-      })
-    })
+        .get('/')
+        .expect(200, 'session saved', function (err) {
+          if (err) return done(err);
+          assert.ok(saved);
+          done();
+        });
+    });
 
     it('should have saved session with updated cookie expiration', function (done) {
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ cookie: { maxAge: min }, store: store }, function (req, res) {
-        req.session.user = 'bob'
-        res.end(req.session.id)
-      })
+        req.session.user = 'bob';
+        res.end(req.session.id);
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, function (err, res) {
-        if (err) return done(err)
-        var id = res.text
-        store.get(id, function (err, sess) {
-          if (err) return done(err)
-          assert.ok(sess, 'session saved to store')
-          var exp = new Date(sess.cookie.expires)
-          assert.strictEqual(exp.toUTCString(), expires(res))
-          setTimeout(function () {
-            request(server)
-            .get('/')
-            .set('Cookie', cookie(res))
-            .expect(200, function (err, res) {
-              if (err) return done(err)
-              store.get(id, function (err, sess) {
-                if (err) return done(err)
-                assert.strictEqual(res.text, id)
-                assert.ok(sess, 'session still in store')
-                assert.notStrictEqual(new Date(sess.cookie.expires).toUTCString(), exp.toUTCString(), 'session cookie expiration updated')
-                done()
-              })
-            })
-          }, (1000 - (Date.now() % 1000) + 200))
-        })
-      })
-    })
-  })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, function (err, res) {
+          if (err) return done(err);
+          var id = res.text;
+          store.get(id, function (err, sess) {
+            if (err) return done(err);
+            assert.ok(sess, 'session saved to store');
+            var exp = new Date(sess.cookie.expires);
+            assert.strictEqual(exp.toUTCString(), expires(res));
+            setTimeout(function () {
+              request(server)
+                .get('/')
+                .set('Cookie', cookie(res))
+                .expect(200, function (err, res) {
+                  if (err) return done(err);
+                  store.get(id, function (err, sess) {
+                    if (err) return done(err);
+                    assert.strictEqual(res.text, id);
+                    assert.ok(sess, 'session still in store');
+                    assert.notStrictEqual(new Date(sess.cookie.expires).toUTCString(), exp.toUTCString(), 'session cookie expiration updated');
+                    done();
+                  });
+                });
+            }, (1000 - (Date.now() % 1000) + 200));
+          });
+        });
+    });
+  });
 
   describe('when sid not in store', function () {
     it('should create a new session', function (done) {
-      var count = 0
-      var store = new session.MemoryStore()
+      var count = 0;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.num = req.session.num || ++count
-        res.end('session ' + req.session.num)
+        req.session.num = req.session.num || ++count;
+        res.end('session ' + req.session.num);
       });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, 'session 1', function (err, res) {
-        if (err) return done(err)
-        store.clear(function (err) {
-          if (err) return done(err)
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, 'session 2', done)
-        })
-      })
-    })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, 'session 1', function (err, res) {
+          if (err) return done(err);
+          store.clear(function (err) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, 'session 2', done);
+          });
+        });
+    });
 
     it('should have a new sid', function (done) {
-      var count = 0
-      var store = new session.MemoryStore()
+      var count = 0;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.num = req.session.num || ++count
-        res.end('session ' + req.session.num)
+        req.session.num = req.session.num || ++count;
+        res.end('session ' + req.session.num);
       });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, 'session 1', function (err, res) {
-        if (err) return done(err)
-        store.clear(function (err) {
-          if (err) return done(err)
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(shouldSetCookie('connect.sid'))
-          .expect(shouldSetCookieToDifferentSessionId(res))
-          .expect(200, 'session 2', done)
-        })
-      })
-    })
-  })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, 'session 1', function (err, res) {
+          if (err) return done(err);
+          store.clear(function (err) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetCookie('connect.sid'))
+              .expect(shouldSetCookieToDifferentSessionId(res))
+              .expect(200, 'session 2', done);
+          });
+        });
+    });
+  });
 
   describe('when sid not properly signed', function () {
     it('should generate new session', function (done) {
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, key: 'sessid' }, function (req, res) {
-        var isnew = req.session.active === undefined
-        req.session.active = true
-        res.end('session ' + (isnew ? 'created' : 'read'))
-      })
+        var isnew = req.session.active === undefined;
+        req.session.active = true;
+        res.end('session ' + (isnew ? 'created' : 'read'));
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('sessid'))
-      .expect(200, 'session created', function (err, res) {
-        if (err) return done(err)
-        var val = sid(res)
-        assert.ok(val)
-        request(server)
         .get('/')
-        .set('Cookie', 'sessid=' + val)
         .expect(shouldSetCookie('sessid'))
-        .expect(shouldSetCookieToDifferentSessionId(val))
-        .expect(200, 'session created', done)
-      })
-    })
+        .expect(200, 'session created', function (err, res) {
+          if (err) return done(err);
+          var val = sid(res);
+          assert.ok(val);
+          request(server)
+            .get('/')
+            .set('Cookie', 'sessid=' + val)
+            .expect(shouldSetCookie('sessid'))
+            .expect(shouldSetCookieToDifferentSessionId(val))
+            .expect(200, 'session created', done);
+        });
+    });
 
     it('should not attempt fetch from store', function (done) {
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, key: 'sessid' }, function (req, res) {
-        var isnew = req.session.active === undefined
-        req.session.active = true
-        res.end('session ' + (isnew ? 'created' : 'read'))
-      })
+        var isnew = req.session.active === undefined;
+        req.session.active = true;
+        res.end('session ' + (isnew ? 'created' : 'read'));
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('sessid'))
-      .expect(200, 'session created', function (err, res) {
-        if (err) return done(err)
-        var val = cookie(res).replace(/...\./, '.')
-
-        assert.ok(val)
-        request(server)
         .get('/')
-        .set('Cookie', val)
         .expect(shouldSetCookie('sessid'))
-        .expect(200, 'session created', done)
-      })
-    })
-  })
+        .expect(200, 'session created', function (err, res) {
+          if (err) return done(err);
+          var val = cookie(res).replace(/...\./, '.');
+
+          assert.ok(val);
+          request(server)
+            .get('/')
+            .set('Cookie', val)
+            .expect(shouldSetCookie('sessid'))
+            .expect(200, 'session created', done);
+        });
+    });
+  });
 
   describe('when session expired in store', function () {
     it('should create a new session', function (done) {
-      var count = 0
-      var store = new session.MemoryStore()
+      var count = 0;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, cookie: { maxAge: 5 } }, function (req, res) {
-        req.session.num = req.session.num || ++count
-        res.end('session ' + req.session.num)
+        req.session.num = req.session.num || ++count;
+        res.end('session ' + req.session.num);
       });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, 'session 1', function (err, res) {
-        if (err) return done(err)
-        setTimeout(function () {
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(shouldSetCookie('connect.sid'))
-          .expect(200, 'session 2', done)
-        }, 20)
-      })
-    })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, 'session 1', function (err, res) {
+          if (err) return done(err);
+          setTimeout(function () {
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetCookie('connect.sid'))
+              .expect(200, 'session 2', done);
+          }, 20);
+        });
+    });
 
     it('should have a new sid', function (done) {
-      var count = 0
-      var store = new session.MemoryStore()
+      var count = 0;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, cookie: { maxAge: 5 } }, function (req, res) {
-        req.session.num = req.session.num || ++count
-        res.end('session ' + req.session.num)
+        req.session.num = req.session.num || ++count;
+        res.end('session ' + req.session.num);
       });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, 'session 1', function (err, res) {
-        if (err) return done(err)
-        setTimeout(function () {
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(shouldSetCookie('connect.sid'))
-          .expect(shouldSetCookieToDifferentSessionId(sid(res)))
-          .expect(200, 'session 2', done)
-        }, 15)
-      })
-    })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, 'session 1', function (err, res) {
+          if (err) return done(err);
+          setTimeout(function () {
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetCookie('connect.sid'))
+              .expect(shouldSetCookieToDifferentSessionId(sid(res)))
+              .expect(200, 'session 2', done);
+          }, 15);
+        });
+    });
 
     it('should not exist in store', function (done) {
-      var count = 0
-      var store = new session.MemoryStore()
+      var count = 0;
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, cookie: { maxAge: 5 } }, function (req, res) {
-        req.session.num = req.session.num || ++count
-        res.end('session ' + req.session.num)
+        req.session.num = req.session.num || ++count;
+        res.end('session ' + req.session.num);
       });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, 'session 1', function (err, res) {
-        if (err) return done(err)
-        setTimeout(function () {
-          store.all(function (err, sess) {
-            if (err) return done(err)
-            assert.strictEqual(Object.keys(sess).length, 0)
-            done()
-          })
-        }, 10)
-      })
-    })
-  })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, 'session 1', function (err, res) {
+          if (err) return done(err);
+          setTimeout(function () {
+            store.all(function (err, sess) {
+              if (err) return done(err);
+              assert.strictEqual(Object.keys(sess).length, 0);
+              done();
+            });
+          }, 10);
+        });
+    });
+  });
 
   describe('proxy option', function(){
     describe('when enabled', function(){
-      var server
+      var server;
       before(function () {
-        server = createServer({ proxy: true, cookie: { secure: true, maxAge: 5 }})
-      })
+        server = createServer({ proxy: true, cookie: { secure: true, maxAge: 5 }});
+      });
 
       it('should trust X-Forwarded-Proto when string', function(done){
         request(server)
-        .get('/')
-        .set('X-Forwarded-Proto', 'https')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, done)
-      })
+          .get('/')
+          .set('X-Forwarded-Proto', 'https')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, done);
+      });
 
       it('should trust X-Forwarded-Proto when comma-separated list', function(done){
         request(server)
-        .get('/')
-        .set('X-Forwarded-Proto', 'https,http')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, done)
-      })
+          .get('/')
+          .set('X-Forwarded-Proto', 'https,http')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, done);
+      });
 
       it('should work when no header', function(done){
         request(server)
-        .get('/')
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, done)
-      })
-    })
+          .get('/')
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, done);
+      });
+    });
 
     describe('when disabled', function(){
       before(function () {
         function setup (req) {
           req.secure = req.headers['x-secure']
-              ? JSON.parse(req.headers['x-secure'])
-              : undefined
+            ? JSON.parse(req.headers['x-secure'])
+            : undefined;
         }
 
         function respond (req, res) {
-          res.end(String(req.secure))
+          res.end(String(req.secure));
         }
 
-        this.server = createServer(setup, { proxy: false, cookie: { secure: true }}, respond)
-      })
+        this.server = createServer(setup, { proxy: false, cookie: { secure: true }}, respond);
+      });
 
       it('should not trust X-Forwarded-Proto', function(done){
         request(this.server)
-        .get('/')
-        .set('X-Forwarded-Proto', 'https')
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, done)
-      })
+          .get('/')
+          .set('X-Forwarded-Proto', 'https')
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, done);
+      });
 
       it('should ignore req.secure', function (done) {
         request(this.server)
-        .get('/')
-        .set('X-Forwarded-Proto', 'https')
-        .set('X-Secure', 'true')
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, 'true', done)
-      })
-    })
+          .get('/')
+          .set('X-Forwarded-Proto', 'https')
+          .set('X-Secure', 'true')
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, 'true', done);
+      });
+    });
 
     describe('when unspecified', function(){
       before(function () {
         function setup (req) {
           req.secure = req.headers['x-secure']
-              ? JSON.parse(req.headers['x-secure'])
-              : undefined
+            ? JSON.parse(req.headers['x-secure'])
+            : undefined;
         }
 
         function respond (req, res) {
-          res.end(String(req.secure))
+          res.end(String(req.secure));
         }
 
-        this.server = createServer(setup, { cookie: { secure: true }}, respond)
-      })
+        this.server = createServer(setup, { cookie: { secure: true }}, respond);
+      });
 
       it('should not trust X-Forwarded-Proto', function(done){
         request(this.server)
-        .get('/')
-        .set('X-Forwarded-Proto', 'https')
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, done)
-      })
+          .get('/')
+          .set('X-Forwarded-Proto', 'https')
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, done);
+      });
 
       it('should use req.secure', function (done) {
         request(this.server)
-        .get('/')
-        .set('X-Forwarded-Proto', 'https')
-        .set('X-Secure', 'true')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, 'true', done)
-      })
-    })
-  })
+          .get('/')
+          .set('X-Forwarded-Proto', 'https')
+          .set('X-Secure', 'true')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, 'true', done);
+      });
+    });
+  });
 
   describe('cookie option', function () {
     describe('when "path" set to "/foo/bar"', function () {
       before(function () {
-        this.server = createServer({ cookie: { path: '/foo/bar' } })
-      })
+        this.server = createServer({ cookie: { path: '/foo/bar' } });
+      });
 
       it('should not set cookie for "/" request', function (done) {
         request(this.server)
-        .get('/')
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, done)
-      })
+          .get('/')
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, done);
+      });
 
       it('should not set cookie for "http://foo/bar" request', function (done) {
         request(this.server)
-        .get('/')
-        .set('host', 'http://foo/bar')
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, done)
-      })
+          .get('/')
+          .set('host', 'http://foo/bar')
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, done);
+      });
 
       it('should set cookie for "/foo/bar" request', function (done) {
         request(this.server)
-        .get('/foo/bar/baz')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, done)
-      })
+          .get('/foo/bar/baz')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, done);
+      });
 
       it('should set cookie for "/foo/bar/baz" request', function (done) {
         request(this.server)
-        .get('/foo/bar/baz')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, done)
-      })
+          .get('/foo/bar/baz')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, done);
+      });
 
       describe('when mounted at "/foo"', function () {
         before(function () {
-          this.server = createServer(mountAt('/foo'), { cookie: { path: '/foo/bar' } })
-        })
+          this.server = createServer(mountAt('/foo'), { cookie: { path: '/foo/bar' } });
+        });
 
         it('should set cookie for "/foo/bar" request', function (done) {
           request(this.server)
-          .get('/foo/bar')
-          .expect(shouldSetCookie('connect.sid'))
-          .expect(200, done)
-        })
+            .get('/foo/bar')
+            .expect(shouldSetCookie('connect.sid'))
+            .expect(200, done);
+        });
 
         it('should not set cookie for "/foo/foo/bar" request', function (done) {
           request(this.server)
-          .get('/foo/foo/bar')
-          .expect(shouldNotHaveHeader('Set-Cookie'))
-          .expect(200, done)
-        })
-      })
-    })
+            .get('/foo/foo/bar')
+            .expect(shouldNotHaveHeader('Set-Cookie'))
+            .expect(200, done);
+        });
+      });
+    });
 
     describe('when "secure" set to "auto"', function () {
       describe('when "proxy" is "true"', function () {
         before(function () {
-          this.server = createServer({ proxy: true, cookie: { maxAge: 5, secure: 'auto' }})
-        })
+          this.server = createServer({ proxy: true, cookie: { maxAge: 5, secure: 'auto' }});
+        });
 
         it('should set secure when X-Forwarded-Proto is https', function (done) {
           request(this.server)
-          .get('/')
-          .set('X-Forwarded-Proto', 'https')
-          .expect(shouldSetCookieWithAttribute('connect.sid', 'Secure'))
-          .expect(200, done)
-        })
-      })
+            .get('/')
+            .set('X-Forwarded-Proto', 'https')
+            .expect(shouldSetCookieWithAttribute('connect.sid', 'Secure'))
+            .expect(200, done);
+        });
+      });
 
       describe('when "proxy" is "false"', function () {
         before(function () {
-          this.server = createServer({ proxy: false, cookie: { maxAge: 5, secure: 'auto' }})
-        })
+          this.server = createServer({ proxy: false, cookie: { maxAge: 5, secure: 'auto' }});
+        });
 
         it('should not set secure when X-Forwarded-Proto is https', function (done) {
           request(this.server)
-          .get('/')
-          .set('X-Forwarded-Proto', 'https')
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
-          .expect(200, done)
-        })
-      })
+            .get('/')
+            .set('X-Forwarded-Proto', 'https')
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
+            .expect(200, done);
+        });
+      });
 
       describe('when "proxy" is undefined', function() {
         before(function () {
           function setup (req) {
-            req.secure = JSON.parse(req.headers['x-secure'])
+            req.secure = JSON.parse(req.headers['x-secure']);
           }
 
           function respond (req, res) {
-            res.end(String(req.secure))
+            res.end(String(req.secure));
           }
 
-          this.server = createServer(setup, { cookie: { secure: 'auto' } }, respond)
-        })
+          this.server = createServer(setup, { cookie: { secure: 'auto' } }, respond);
+        });
 
         it('should set secure if req.secure = true', function (done) {
           request(this.server)
-          .get('/')
-          .set('X-Secure', 'true')
-          .expect(shouldSetCookieWithAttribute('connect.sid', 'Secure'))
-          .expect(200, 'true', done)
-        })
+            .get('/')
+            .set('X-Secure', 'true')
+            .expect(shouldSetCookieWithAttribute('connect.sid', 'Secure'))
+            .expect(200, 'true', done);
+        });
 
         it('should not set secure if req.secure = false', function (done) {
           request(this.server)
-          .get('/')
-          .set('X-Secure', 'false')
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
-          .expect(200, 'false', done)
-        })
-      })
-    })
-  })
+            .get('/')
+            .set('X-Secure', 'false')
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
+            .expect(200, 'false', done);
+        });
+      });
+    });
+  });
 
   describe('genid option', function(){
     it('should reject non-function values', function(){
-      assert.throws(session.bind(null, { genid: 'bogus!' }), /genid.*must/)
+      assert.throws(session.bind(null, { genid: 'bogus!' }), /genid.*must/);
     });
 
     it('should provide default generator', function(done){
       request(createServer())
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done)
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
     });
 
     it('should allow custom function', function(done){
-      function genid() { return 'apple' }
+      function genid() { return 'apple'; }
 
       request(createServer({ genid: genid }))
-      .get('/')
-      .expect(shouldSetCookieToValue('connect.sid', 's%3Aapple.D8Y%2BpkTAmeR0PobOhY4G97PRW%2Bj7bUnP%2F5m6%2FOn1MCU'))
-      .expect(200, done)
+        .get('/')
+        .expect(shouldSetCookieToValue('connect.sid', 's%3Aapple.D8Y%2BpkTAmeR0PobOhY4G97PRW%2Bj7bUnP%2F5m6%2FOn1MCU'))
+        .expect(200, done);
     });
 
     it('should encode unsafe chars', function(done){
-      function genid() { return '%' }
+      function genid() { return '%'; }
 
       request(createServer({ genid: genid }))
-      .get('/')
-      .expect(shouldSetCookieToValue('connect.sid', 's%3A%25.kzQ6x52kKVdF35Qh62AWk4ZekS28K5XYCXKa%2FOTZ01g'))
-      .expect(200, done)
+        .get('/')
+        .expect(shouldSetCookieToValue('connect.sid', 's%3A%25.kzQ6x52kKVdF35Qh62AWk4ZekS28K5XYCXKa%2FOTZ01g'))
+        .expect(200, done);
     });
 
     it('should provide req argument', function(done){
-      function genid(req) { return req.url }
+      function genid(req) { return req.url; }
 
       request(createServer({ genid: genid }))
-      .get('/foo')
-      .expect(shouldSetCookieToValue('connect.sid', 's%3A%2Ffoo.paEKBtAHbV5s1IB8B2zPnzAgYmmnRPIqObW4VRYj%2FMQ'))
-      .expect(200, done)
+        .get('/foo')
+        .expect(shouldSetCookieToValue('connect.sid', 's%3A%2Ffoo.paEKBtAHbV5s1IB8B2zPnzAgYmmnRPIqObW4VRYj%2FMQ'))
+        .expect(200, done);
     });
   });
 
   describe('key option', function(){
     it('should default to "connect.sid"', function(done){
       request(createServer())
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done)
-    })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
+    });
 
     it('should allow overriding', function(done){
       request(createServer({ key: 'session_id' }))
-      .get('/')
-      .expect(shouldSetCookie('session_id'))
-      .expect(200, done)
-    })
-  })
+        .get('/')
+        .expect(shouldSetCookie('session_id'))
+        .expect(200, done);
+    });
+  });
 
   describe('name option', function () {
     it('should default to "connect.sid"', function (done) {
       request(createServer())
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done)
-    })
+        .get('/')
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
+    });
 
     it('should set the cookie name', function (done) {
       request(createServer({ name: 'session_id' }))
-      .get('/')
-      .expect(shouldSetCookie('session_id'))
-      .expect(200, done)
-    })
-  })
+        .get('/')
+        .expect(shouldSetCookie('session_id'))
+        .expect(200, done);
+    });
+  });
 
   describe('rolling option', function(){
     it('should default to false', function(done){
       var server = createServer(null, function (req, res) {
-        req.session.user = 'bob'
-        res.end()
-      })
+        req.session.user = 'bob';
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, function(err, res){
-        if (err) return done(err);
-        request(server)
         .get('/')
-        .set('Cookie', cookie(res))
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, done)
-      });
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, function(err, res){
+          if (err) return done(err);
+          request(server)
+            .get('/')
+            .set('Cookie', cookie(res))
+            .expect(shouldNotHaveHeader('Set-Cookie'))
+            .expect(200, done);
+        });
     });
 
     it('should force cookie on unmodified session', function(done){
       var server = createServer({ rolling: true }, function (req, res) {
-        req.session.user = 'bob'
-        res.end()
-      })
+        req.session.user = 'bob';
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, function(err, res){
-        if (err) return done(err);
-        request(server)
         .get('/')
-        .set('Cookie', cookie(res))
         .expect(shouldSetCookie('connect.sid'))
-        .expect(200, done)
-      });
+        .expect(200, function(err, res){
+          if (err) return done(err);
+          request(server)
+            .get('/')
+            .set('Cookie', cookie(res))
+            .expect(shouldSetCookie('connect.sid'))
+            .expect(200, done);
+        });
     });
 
     it('should not force cookie on uninitialized session if saveUninitialized option is set to false', function(done){
-      var store = new session.MemoryStore()
-      var server = createServer({ store: store, rolling: true, saveUninitialized: false })
+      var store = new session.MemoryStore();
+      var server = createServer({ store: store, rolling: true, saveUninitialized: false });
 
       request(server)
-      .get('/')
-      .expect(shouldNotSetSessionInStore(store))
-      .expect(shouldNotHaveHeader('Set-Cookie'))
-      .expect(200, done)
+        .get('/')
+        .expect(shouldNotSetSessionInStore(store))
+        .expect(shouldNotHaveHeader('Set-Cookie'))
+        .expect(200, done);
     });
 
     it('should force cookie and save uninitialized session if saveUninitialized option is set to true', function(done){
-      var store = new session.MemoryStore()
-      var server = createServer({ store: store, rolling: true, saveUninitialized: true })
+      var store = new session.MemoryStore();
+      var server = createServer({ store: store, rolling: true, saveUninitialized: true });
 
       request(server)
-      .get('/')
-      .expect(shouldSetSessionInStore(store))
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done)
+        .get('/')
+        .expect(shouldSetSessionInStore(store))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
     });
 
     it('should force cookie and save modified session even if saveUninitialized option is set to false', function(done){
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, rolling: true, saveUninitialized: false }, function (req, res) {
-        req.session.user = 'bob'
-        res.end()
-      })
+        req.session.user = 'bob';
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetSessionInStore(store))
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done);
+        .get('/')
+        .expect(shouldSetSessionInStore(store))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
     });
   });
 
   describe('resave option', function(){
     it('should default to true', function(done){
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.user = 'bob'
-        res.end()
-      })
+        req.session.user = 'bob';
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetSessionInStore(store))
-      .expect(200, function(err, res){
-        if (err) return done(err);
-        request(server)
         .get('/')
-        .set('Cookie', cookie(res))
         .expect(shouldSetSessionInStore(store))
-        .expect(200, done);
-      });
+        .expect(200, function(err, res){
+          if (err) return done(err);
+          request(server)
+            .get('/')
+            .set('Cookie', cookie(res))
+            .expect(shouldSetSessionInStore(store))
+            .expect(200, done);
+        });
     });
 
     describe('when true', function () {
       it('should force save on unmodified session', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ store: store, resave: true }, function (req, res) {
-          req.session.user = 'bob'
-          res.end()
-        })
+          req.session.user = 'bob';
+          res.end();
+        });
 
         request(server)
-        .get('/')
-        .expect(shouldSetSessionInStore(store))
-        .expect(200, function (err, res) {
-          if (err) return done(err)
-          request(server)
           .get('/')
-          .set('Cookie', cookie(res))
           .expect(shouldSetSessionInStore(store))
-          .expect(200, done)
-        })
-      })
-    })
+          .expect(200, function (err, res) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetSessionInStore(store))
+              .expect(200, done);
+          });
+      });
+    });
 
     describe('when false', function () {
       it('should prevent save on unmodified session', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ store: store, resave: false }, function (req, res) {
-          req.session.user = 'bob'
-          res.end()
-        })
+          req.session.user = 'bob';
+          res.end();
+        });
 
         request(server)
-        .get('/')
-        .expect(shouldSetSessionInStore(store))
-        .expect(200, function (err, res) {
-          if (err) return done(err)
-          request(server)
           .get('/')
-          .set('Cookie', cookie(res))
-          .expect(shouldNotSetSessionInStore(store))
-          .expect(200, done)
-        })
-      })
+          .expect(shouldSetSessionInStore(store))
+          .expect(200, function (err, res) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldNotSetSessionInStore(store))
+              .expect(200, done);
+          });
+      });
 
       it('should still save modified session', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ resave: false, store: store }, function (req, res) {
           if (req.method === 'PUT') {
-            req.session.token = req.url.substr(1)
+            req.session.token = req.url.substr(1);
           }
-          res.end('token=' + (req.session.token || ''))
-        })
+          res.end('token=' + (req.session.token || ''));
+        });
 
         request(server)
-        .put('/w6RHhwaA')
-        .expect(200)
-        .expect(shouldSetSessionInStore(store))
-        .expect('token=w6RHhwaA')
-        .end(function (err, res) {
-          if (err) return done(err)
-          var sess = cookie(res)
-          request(server)
-          .get('/')
-          .set('Cookie', sess)
+          .put('/w6RHhwaA')
           .expect(200)
-          .expect(shouldNotSetSessionInStore(store))
+          .expect(shouldSetSessionInStore(store))
           .expect('token=w6RHhwaA')
-          .end(function (err) {
-            if (err) return done(err)
+          .end(function (err, res) {
+            if (err) return done(err);
+            var sess = cookie(res);
             request(server)
-            .put('/zfQ3rzM3')
-            .set('Cookie', sess)
-            .expect(200)
-            .expect(shouldSetSessionInStore(store))
-            .expect('token=zfQ3rzM3')
-            .end(done)
-          })
-        })
-      })
+              .get('/')
+              .set('Cookie', sess)
+              .expect(200)
+              .expect(shouldNotSetSessionInStore(store))
+              .expect('token=w6RHhwaA')
+              .end(function (err) {
+                if (err) return done(err);
+                request(server)
+                  .put('/zfQ3rzM3')
+                  .set('Cookie', sess)
+                  .expect(200)
+                  .expect(shouldSetSessionInStore(store))
+                  .expect('token=zfQ3rzM3')
+                  .end(done);
+              });
+          });
+      });
 
       it('should detect a "cookie" property as modified', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ store: store, resave: false }, function (req, res) {
-          req.session.user = req.session.user || {}
-          req.session.user.name = 'bob'
-          req.session.user.cookie = req.session.user.cookie || 0
-          req.session.user.cookie++
-          res.end()
-        })
+          req.session.user = req.session.user || {};
+          req.session.user.name = 'bob';
+          req.session.user.cookie = req.session.user.cookie || 0;
+          req.session.user.cookie++;
+          res.end();
+        });
 
         request(server)
-        .get('/')
-        .expect(shouldSetSessionInStore(store))
-        .expect(200, function (err, res) {
-          if (err) return done(err)
-          request(server)
           .get('/')
-          .set('Cookie', cookie(res))
           .expect(shouldSetSessionInStore(store))
-          .expect(200, done)
-        })
-      })
+          .expect(200, function (err, res) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetSessionInStore(store))
+              .expect(200, done);
+          });
+      });
 
       it('should pass session touch error', function (done) {
-        var cb = after(2, done)
-        var store = new session.MemoryStore()
+        var cb = after(2, done);
+        var store = new session.MemoryStore();
         var server = createServer({ store: store, resave: false }, function (req, res) {
-          req.session.hit = true
-          res.end('session saved')
-        })
+          req.session.hit = true;
+          res.end('session saved');
+        });
 
         store.touch = function touch (sid, sess, callback) {
-          callback(new Error('boom!'))
-        }
+          callback(new Error('boom!'));
+        };
 
         server.on('error', function onerror (err) {
-          assert.ok(err)
-          assert.strictEqual(err.message, 'boom!')
-          cb()
-        })
+          assert.ok(err);
+          assert.strictEqual(err.message, 'boom!');
+          cb();
+        });
 
         request(server)
-        .get('/')
-        .expect(200, 'session saved', function (err, res) {
-          if (err) return cb(err)
-          request(server)
           .get('/')
-          .set('Cookie', cookie(res))
-          .end(cb)
-        })
-      })
-    })
+          .expect(200, 'session saved', function (err, res) {
+            if (err) return cb(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .end(cb);
+          });
+      });
+    });
   });
 
   describe('saveUninitialized option', function(){
     it('should default to true', function(done){
-      var store = new session.MemoryStore()
-      var server = createServer({ store: store })
+      var store = new session.MemoryStore();
+      var server = createServer({ store: store });
 
       request(server)
-      .get('/')
-      .expect(shouldSetSessionInStore(store))
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done);
+        .get('/')
+        .expect(shouldSetSessionInStore(store))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
     });
 
     it('should force save of uninitialized session', function(done){
-      var store = new session.MemoryStore()
-      var server = createServer({ store: store, saveUninitialized: true })
+      var store = new session.MemoryStore();
+      var server = createServer({ store: store, saveUninitialized: true });
 
       request(server)
-      .get('/')
-      .expect(shouldSetSessionInStore(store))
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done);
+        .get('/')
+        .expect(shouldSetSessionInStore(store))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
     });
 
     it('should prevent save of uninitialized session', function(done){
-      var store = new session.MemoryStore()
-      var server = createServer({ store: store, saveUninitialized: false })
+      var store = new session.MemoryStore();
+      var server = createServer({ store: store, saveUninitialized: false });
 
       request(server)
-      .get('/')
-      .expect(shouldNotSetSessionInStore(store))
-      .expect(shouldNotHaveHeader('Set-Cookie'))
-      .expect(200, done)
+        .get('/')
+        .expect(shouldNotSetSessionInStore(store))
+        .expect(shouldNotHaveHeader('Set-Cookie'))
+        .expect(200, done);
     });
 
     it('should still save modified session', function(done){
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, saveUninitialized: false }, function (req, res) {
-        req.session.count = req.session.count || 0
-        req.session.count++
-        res.end()
-      })
+        req.session.count = req.session.count || 0;
+        req.session.count++;
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldSetSessionInStore(store))
-      .expect(shouldSetCookie('connect.sid'))
-      .expect(200, done);
+        .get('/')
+        .expect(shouldSetSessionInStore(store))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done);
     });
 
     it('should pass session save error', function (done) {
-      var cb = after(2, done)
-      var store = new session.MemoryStore()
+      var cb = after(2, done);
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, saveUninitialized: true }, function (req, res) {
-        res.end('session saved')
-      })
+        res.end('session saved');
+      });
 
       store.set = function destroy(sid, sess, callback) {
-        callback(new Error('boom!'))
-      }
+        callback(new Error('boom!'));
+      };
 
       server.on('error', function onerror(err) {
-        assert.ok(err)
-        assert.strictEqual(err.message, 'boom!')
-        cb()
-      })
+        assert.ok(err);
+        assert.strictEqual(err.message, 'boom!');
+        cb();
+      });
 
       request(server)
-      .get('/')
-      .expect(200, 'session saved', cb)
-    })
+        .get('/')
+        .expect(200, 'session saved', cb);
+    });
 
     it('should prevent uninitialized session from being touched', function (done) {
-      var cb = after(1, done)
-      var store = new session.MemoryStore()
+      var cb = after(1, done);
+      var store = new session.MemoryStore();
       var server = createServer({ saveUninitialized: false, store: store, cookie: { maxAge: min } }, function (req, res) {
-        res.end()
-      })
+        res.end();
+      });
 
       store.touch = function () {
-        cb(new Error('should not be called'))
-      }
+        cb(new Error('should not be called'));
+      };
 
       request(server)
-      .get('/')
-      .expect(200, cb)
-    })
+        .get('/')
+        .expect(200, cb);
+    });
   });
 
   describe('secret option', function () {
     it('should reject empty arrays', function () {
       assert.throws(createServer.bind(null, { secret: [] }), /secret option array/);
-    })
+    });
 
     describe('when an array', function () {
       it('should sign cookies', function (done) {
@@ -1227,10 +1227,10 @@ describe('session()', function(){
         });
 
         request(server)
-        .get('/')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, 'bob', done);
-      })
+          .get('/')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, 'bob', done);
+      });
 
       it('should sign cookies with first element', function (done) {
         var store = new session.MemoryStore();
@@ -1245,15 +1245,15 @@ describe('session()', function(){
         });
 
         request(server1)
-        .get('/')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, 'bob', function (err, res) {
-          if (err) return done(err);
-          request(server2)
           .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, 'undefined', done);
-        });
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, 'bob', function (err, res) {
+            if (err) return done(err);
+            request(server2)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, 'undefined', done);
+          });
       });
 
       it('should read cookies using all elements', function (done) {
@@ -1269,683 +1269,683 @@ describe('session()', function(){
         });
 
         request(server1)
-        .get('/')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, 'bob', function (err, res) {
-          if (err) return done(err);
-          request(server2)
           .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, 'bob', done);
-        });
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, 'bob', function (err, res) {
+            if (err) return done(err);
+            request(server2)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, 'bob', done);
+          });
       });
-    })
-  })
+    });
+  });
 
   describe('unset option', function () {
     it('should reject unknown values', function(){
-      assert.throws(session.bind(null, { unset: 'bogus!' }), /unset.*must/)
+      assert.throws(session.bind(null, { unset: 'bogus!' }), /unset.*must/);
     });
 
     it('should default to keep', function(done){
       var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.count = req.session.count || 0
-        req.session.count++
-        if (req.session.count === 2) req.session = null
-        res.end()
-      })
+        req.session.count = req.session.count || 0;
+        req.session.count++;
+        if (req.session.count === 2) req.session = null;
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(200, function(err, res){
-        if (err) return done(err);
-        store.length(function(err, len){
+        .get('/')
+        .expect(200, function(err, res){
           if (err) return done(err);
-          assert.strictEqual(len, 1)
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, function(err, res){
+          store.length(function(err, len){
             if (err) return done(err);
-            store.length(function(err, len){
-              if (err) return done(err);
-              assert.strictEqual(len, 1)
-              done();
-            });
+            assert.strictEqual(len, 1);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, function(err, res){
+                if (err) return done(err);
+                store.length(function(err, len){
+                  if (err) return done(err);
+                  assert.strictEqual(len, 1);
+                  done();
+                });
+              });
           });
         });
-      });
     });
 
     it('should allow destroy on req.session = null', function(done){
       var store = new session.MemoryStore();
       var server = createServer({ store: store, unset: 'destroy' }, function (req, res) {
-        req.session.count = req.session.count || 0
-        req.session.count++
-        if (req.session.count === 2) req.session = null
-        res.end()
-      })
+        req.session.count = req.session.count || 0;
+        req.session.count++;
+        if (req.session.count === 2) req.session = null;
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(200, function(err, res){
-        if (err) return done(err);
-        store.length(function(err, len){
+        .get('/')
+        .expect(200, function(err, res){
           if (err) return done(err);
-          assert.strictEqual(len, 1)
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, function(err, res){
+          store.length(function(err, len){
             if (err) return done(err);
-            store.length(function(err, len){
-              if (err) return done(err);
-              assert.strictEqual(len, 0)
-              done();
-            });
+            assert.strictEqual(len, 1);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, function(err, res){
+                if (err) return done(err);
+                store.length(function(err, len){
+                  if (err) return done(err);
+                  assert.strictEqual(len, 0);
+                  done();
+                });
+              });
           });
         });
-      });
     });
 
     it('should not set cookie if initial session destroyed', function(done){
       var store = new session.MemoryStore();
       var server = createServer({ store: store, unset: 'destroy' }, function (req, res) {
-        req.session = null
-        res.end()
-      })
+        req.session = null;
+        res.end();
+      });
 
       request(server)
-      .get('/')
-      .expect(shouldNotHaveHeader('Set-Cookie'))
-      .expect(200, function(err, res){
-        if (err) return done(err);
-        store.length(function(err, len){
+        .get('/')
+        .expect(shouldNotHaveHeader('Set-Cookie'))
+        .expect(200, function(err, res){
           if (err) return done(err);
-          assert.strictEqual(len, 0)
-          done();
+          store.length(function(err, len){
+            if (err) return done(err);
+            assert.strictEqual(len, 0);
+            done();
+          });
         });
-      });
     });
 
     it('should pass session destroy error', function (done) {
-      var cb = after(2, done)
-      var store = new session.MemoryStore()
+      var cb = after(2, done);
+      var store = new session.MemoryStore();
       var server = createServer({ store: store, unset: 'destroy' }, function (req, res) {
-        req.session = null
-        res.end('session destroyed')
-      })
+        req.session = null;
+        res.end('session destroyed');
+      });
 
       store.destroy = function destroy(sid, callback) {
-        callback(new Error('boom!'))
-      }
+        callback(new Error('boom!'));
+      };
 
       server.on('error', function onerror(err) {
-        assert.ok(err)
-        assert.strictEqual(err.message, 'boom!')
-        cb()
-      })
+        assert.ok(err);
+        assert.strictEqual(err.message, 'boom!');
+        cb();
+      });
 
       request(server)
-      .get('/')
-      .expect(200, 'session destroyed', cb)
-    })
+        .get('/')
+        .expect(200, 'session destroyed', cb);
+    });
   });
 
   describe('res.end patch', function () {
     it('should correctly handle res.end/res.write patched prior', function (done) {
       function setup (req, res) {
-        writePatch(res)
+        writePatch(res);
       }
 
       function respond (req, res) {
-        req.session.hit = true
-        res.write('hello, ')
-        res.end('world')
+        req.session.hit = true;
+        res.write('hello, ');
+        res.end('world');
       }
 
       request(createServer(setup, null, respond))
-      .get('/')
-      .expect(200, 'hello, world', done)
-    })
+        .get('/')
+        .expect(200, 'hello, world', done);
+    });
 
     it('should correctly handle res.end/res.write patched after', function (done) {
       function respond (req, res) {
-        writePatch(res)
-        req.session.hit = true
-        res.write('hello, ')
-        res.end('world')
+        writePatch(res);
+        req.session.hit = true;
+        res.write('hello, ');
+        res.end('world');
       }
 
       request(createServer(null, respond))
-      .get('/')
-      .expect(200, 'hello, world', done)
-    })
-  })
+        .get('/')
+        .expect(200, 'hello, world', done);
+    });
+  });
 
   describe('req.session', function(){
     it('should persist', function(done){
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.count = req.session.count || 0
-        req.session.count++
-        res.end('hits: ' + req.session.count)
-      })
+        req.session.count = req.session.count || 0;
+        req.session.count++;
+        res.end('hits: ' + req.session.count);
+      });
 
       request(server)
-      .get('/')
-      .expect(200, 'hits: 1', function (err, res) {
-        if (err) return done(err)
-        store.load(sid(res), function (err, sess) {
-          if (err) return done(err)
-          assert.ok(sess)
-          request(server)
-          .get('/')
-          .set('Cookie', cookie(res))
-          .expect(200, 'hits: 2', done)
-        })
-      })
-    })
+        .get('/')
+        .expect(200, 'hits: 1', function (err, res) {
+          if (err) return done(err);
+          store.load(sid(res), function (err, sess) {
+            if (err) return done(err);
+            assert.ok(sess);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(200, 'hits: 2', done);
+          });
+        });
+    });
 
     it('should only set-cookie when modified', function(done){
       var modify = true;
       var server = createServer(null, function (req, res) {
         if (modify) {
-          req.session.count = req.session.count || 0
-          req.session.count++
+          req.session.count = req.session.count || 0;
+          req.session.count++;
         }
-        res.end(req.session.count.toString())
-      })
+        res.end(req.session.count.toString());
+      });
 
       request(server)
-      .get('/')
-      .expect(200, '1', function (err, res) {
-        if (err) return done(err)
-        request(server)
         .get('/')
-        .set('Cookie', cookie(res))
-        .expect(200, '2', function (err, res) {
-          if (err) return done(err)
-          var val = cookie(res);
-          modify = false;
-
+        .expect(200, '1', function (err, res) {
+          if (err) return done(err);
           request(server)
-          .get('/')
-          .set('Cookie', val)
-          .expect(shouldNotHaveHeader('Set-Cookie'))
-          .expect(200, '2', function (err, res) {
-            if (err) return done(err)
-            modify = true;
-
-            request(server)
             .get('/')
-            .set('Cookie', val)
-            .expect(shouldSetCookie('connect.sid'))
-            .expect(200, '3', done)
-          });
+            .set('Cookie', cookie(res))
+            .expect(200, '2', function (err, res) {
+              if (err) return done(err);
+              var val = cookie(res);
+              modify = false;
+
+              request(server)
+                .get('/')
+                .set('Cookie', val)
+                .expect(shouldNotHaveHeader('Set-Cookie'))
+                .expect(200, '2', function (err, res) {
+                  if (err) return done(err);
+                  modify = true;
+
+                  request(server)
+                    .get('/')
+                    .set('Cookie', val)
+                    .expect(shouldSetCookie('connect.sid'))
+                    .expect(200, '3', done);
+                });
+            });
         });
-      });
-    })
+    });
 
     it('should not have enumerable methods', function (done) {
       var server = createServer(null, function (req, res) {
-        req.session.foo = 'foo'
-        req.session.bar = 'bar'
-        var keys = []
+        req.session.foo = 'foo';
+        req.session.bar = 'bar';
+        var keys = [];
         for (var key in req.session) {
-          keys.push(key)
+          keys.push(key);
         }
-        res.end(keys.sort().join(','))
-      })
+        res.end(keys.sort().join(','));
+      });
 
       request(server)
-      .get('/')
-      .expect(200, 'bar,cookie,foo', done);
+        .get('/')
+        .expect(200, 'bar,cookie,foo', done);
     });
 
     it('should not be set if store is disconnected', function (done) {
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        res.end(typeof req.session)
-      })
+        res.end(typeof req.session);
+      });
 
-      store.emit('disconnect')
+      store.emit('disconnect');
 
       request(server)
-      .get('/')
-      .expect(shouldNotHaveHeader('Set-Cookie'))
-      .expect(200, 'undefined', done)
-    })
+        .get('/')
+        .expect(shouldNotHaveHeader('Set-Cookie'))
+        .expect(200, 'undefined', done);
+    });
 
     it('should be set when store reconnects', function (done) {
-      var store = new session.MemoryStore()
+      var store = new session.MemoryStore();
       var server = createServer({ store: store }, function (req, res) {
-        res.end(typeof req.session)
-      })
+        res.end(typeof req.session);
+      });
 
-      store.emit('disconnect')
+      store.emit('disconnect');
 
       request(server)
-      .get('/')
-      .expect(shouldNotHaveHeader('Set-Cookie'))
-      .expect(200, 'undefined', function (err) {
-        if (err) return done(err)
-
-        store.emit('connect')
-
-        request(server)
         .get('/')
-        .expect(200, 'object', done)
-      })
-    })
+        .expect(shouldNotHaveHeader('Set-Cookie'))
+        .expect(200, 'undefined', function (err) {
+          if (err) return done(err);
+
+          store.emit('connect');
+
+          request(server)
+            .get('/')
+            .expect(200, 'object', done);
+        });
+    });
 
     describe('.destroy()', function(){
       it('should destroy the previous session', function(done){
         var server = createServer(null, function (req, res) {
           req.session.destroy(function (err) {
-            if (err) res.statusCode = 500
-            res.end(String(req.session))
-          })
-        })
+            if (err) res.statusCode = 500;
+            res.end(String(req.session));
+          });
+        });
 
         request(server)
-        .get('/')
-        .expect(shouldNotHaveHeader('Set-Cookie'))
-        .expect(200, 'undefined', done)
-      })
-    })
+          .get('/')
+          .expect(shouldNotHaveHeader('Set-Cookie'))
+          .expect(200, 'undefined', done);
+      });
+    });
 
     describe('.regenerate()', function(){
       it('should destroy/replace the previous session', function(done){
         var server = createServer(null, function (req, res) {
-          var id = req.session.id
+          var id = req.session.id;
           req.session.regenerate(function (err) {
-            if (err) res.statusCode = 500
-            res.end(String(req.session.id === id))
-          })
-        })
+            if (err) res.statusCode = 500;
+            res.end(String(req.session.id === id));
+          });
+        });
 
         request(server)
-        .get('/')
-        .expect(shouldSetCookie('connect.sid'))
-        .expect(200, function (err, res) {
-          if (err) return done(err)
-          request(server)
           .get('/')
-          .set('Cookie', cookie(res))
           .expect(shouldSetCookie('connect.sid'))
-          .expect(shouldSetCookieToDifferentSessionId(sid(res)))
-          .expect(200, 'false', done)
-        });
-      })
-    })
+          .expect(200, function (err, res) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetCookie('connect.sid'))
+              .expect(shouldSetCookieToDifferentSessionId(sid(res)))
+              .expect(200, 'false', done);
+          });
+      });
+    });
 
     describe('.reload()', function () {
       it('should reload session from store', function (done) {
         var server = createServer(null, function (req, res) {
           if (req.url === '/') {
-            req.session.active = true
-            res.end('session created')
-            return
+            req.session.active = true;
+            res.end('session created');
+            return;
           }
 
-          req.session.url = req.url
+          req.session.url = req.url;
 
           if (req.url === '/bar') {
-            res.end('saw ' + req.session.url)
-            return
+            res.end('saw ' + req.session.url);
+            return;
           }
 
           request(server)
-          .get('/bar')
-          .set('Cookie', val)
-          .expect(200, 'saw /bar', function (err, resp) {
-            if (err) return done(err)
-            req.session.reload(function (err) {
-              if (err) return done(err)
-              res.end('saw ' + req.session.url)
-            })
-          })
-        })
-        var val
+            .get('/bar')
+            .set('Cookie', val)
+            .expect(200, 'saw /bar', function (err, resp) {
+              if (err) return done(err);
+              req.session.reload(function (err) {
+                if (err) return done(err);
+                res.end('saw ' + req.session.url);
+              });
+            });
+        });
+        var val;
 
         request(server)
-        .get('/')
-        .expect(200, 'session created', function (err, res) {
-          if (err) return done(err)
-          val = cookie(res)
-          request(server)
-          .get('/foo')
-          .set('Cookie', val)
-          .expect(200, 'saw /bar', done)
-        })
-      })
+          .get('/')
+          .expect(200, 'session created', function (err, res) {
+            if (err) return done(err);
+            val = cookie(res);
+            request(server)
+              .get('/foo')
+              .set('Cookie', val)
+              .expect(200, 'saw /bar', done);
+          });
+      });
 
       it('should error is session missing', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ store: store }, function (req, res) {
           if (req.url === '/') {
-            req.session.active = true
-            res.end('session created')
-            return
+            req.session.active = true;
+            res.end('session created');
+            return;
           }
 
           store.clear(function (err) {
-            if (err) return done(err)
+            if (err) return done(err);
             req.session.reload(function (err) {
-              res.statusCode = err ? 500 : 200
-              res.end(err ? err.message : '')
-            })
-          })
-        })
+              res.statusCode = err ? 500 : 200;
+              res.end(err ? err.message : '');
+            });
+          });
+        });
 
         request(server)
-        .get('/')
-        .expect(200, 'session created', function (err, res) {
-          if (err) return done(err)
-          request(server)
-          .get('/foo')
-          .set('Cookie', cookie(res))
-          .expect(500, 'failed to load session', done)
-        })
-      })
-    })
+          .get('/')
+          .expect(200, 'session created', function (err, res) {
+            if (err) return done(err);
+            request(server)
+              .get('/foo')
+              .set('Cookie', cookie(res))
+              .expect(500, 'failed to load session', done);
+          });
+      });
+    });
 
     describe('.save()', function () {
       it('should save session to store', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ store: store }, function (req, res) {
-          req.session.hit = true
+          req.session.hit = true;
           req.session.save(function (err) {
-            if (err) return res.end(err.message)
+            if (err) return res.end(err.message);
             store.get(req.session.id, function (err, sess) {
-              if (err) return res.end(err.message)
-              res.end(sess ? 'stored' : 'empty')
-            })
-          })
-        })
+              if (err) return res.end(err.message);
+              res.end(sess ? 'stored' : 'empty');
+            });
+          });
+        });
 
         request(server)
-        .get('/')
-        .expect(200, 'stored', done)
-      })
+          .get('/')
+          .expect(200, 'stored', done);
+      });
 
       it('should prevent end-of-request save', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ store: store }, function (req, res) {
-          req.session.hit = true
+          req.session.hit = true;
           req.session.save(function (err) {
-            if (err) return res.end(err.message)
-            res.end('saved')
-          })
-        })
+            if (err) return res.end(err.message);
+            res.end('saved');
+          });
+        });
 
         request(server)
-        .get('/')
-        .expect(shouldSetSessionInStore(store))
-        .expect(200, 'saved', function (err, res) {
-          if (err) return done(err)
-          request(server)
           .get('/')
-          .set('Cookie', cookie(res))
           .expect(shouldSetSessionInStore(store))
-          .expect(200, 'saved', done)
-        })
-      })
+          .expect(200, 'saved', function (err, res) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetSessionInStore(store))
+              .expect(200, 'saved', done);
+          });
+      });
 
       it('should prevent end-of-request save on reloaded session', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ store: store }, function (req, res) {
-          req.session.hit = true
+          req.session.hit = true;
           req.session.reload(function () {
             req.session.save(function (err) {
-              if (err) return res.end(err.message)
-              res.end('saved')
-            })
-          })
-        })
+              if (err) return res.end(err.message);
+              res.end('saved');
+            });
+          });
+        });
 
         request(server)
-        .get('/')
-        .expect(shouldSetSessionInStore(store))
-        .expect(200, 'saved', function (err, res) {
-          if (err) return done(err)
-          request(server)
           .get('/')
-          .set('Cookie', cookie(res))
           .expect(shouldSetSessionInStore(store))
-          .expect(200, 'saved', done)
-        })
-      })
-    })
+          .expect(200, 'saved', function (err, res) {
+            if (err) return done(err);
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetSessionInStore(store))
+              .expect(200, 'saved', done);
+          });
+      });
+    });
 
     describe('.touch()', function () {
       it('should reset session expiration', function (done) {
-        var store = new session.MemoryStore()
+        var store = new session.MemoryStore();
         var server = createServer({ resave: false, store: store, cookie: { maxAge: min } }, function (req, res) {
-          req.session.hit = true
-          req.session.touch()
-          res.end()
-        })
+          req.session.hit = true;
+          req.session.touch();
+          res.end();
+        });
 
         request(server)
-        .get('/')
-        .expect(200, function (err, res) {
-          if (err) return done(err)
-          var id = sid(res)
-          store.get(id, function (err, sess) {
-            if (err) return done(err)
-            var exp = new Date(sess.cookie.expires)
-            setTimeout(function () {
-              request(server)
-              .get('/')
-              .set('Cookie', cookie(res))
-              .expect(200, function (err, res) {
-                if (err) return done(err);
-                store.get(id, function (err, sess) {
-                  if (err) return done(err)
-                  assert.notStrictEqual(new Date(sess.cookie.expires).getTime(), exp.getTime())
-                  done()
-                })
-              })
-            }, 100)
-          })
-        })
-      })
-    })
+          .get('/')
+          .expect(200, function (err, res) {
+            if (err) return done(err);
+            var id = sid(res);
+            store.get(id, function (err, sess) {
+              if (err) return done(err);
+              var exp = new Date(sess.cookie.expires);
+              setTimeout(function () {
+                request(server)
+                  .get('/')
+                  .set('Cookie', cookie(res))
+                  .expect(200, function (err, res) {
+                    if (err) return done(err);
+                    store.get(id, function (err, sess) {
+                      if (err) return done(err);
+                      assert.notStrictEqual(new Date(sess.cookie.expires).getTime(), exp.getTime());
+                      done();
+                    });
+                  });
+              }, 100);
+            });
+          });
+      });
+    });
 
     describe('.cookie', function(){
       describe('.*', function(){
         it('should serialize as parameters', function(done){
           var server = createServer({ proxy: true }, function (req, res) {
-            req.session.cookie.httpOnly = false
-            req.session.cookie.secure = true
-            res.end()
-          })
+            req.session.cookie.httpOnly = false;
+            req.session.cookie.secure = true;
+            res.end();
+          });
 
           request(server)
-          .get('/')
-          .set('X-Forwarded-Proto', 'https')
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'HttpOnly'))
-          .expect(shouldSetCookieWithAttribute('connect.sid', 'Secure'))
-          .expect(200, done)
-        })
+            .get('/')
+            .set('X-Forwarded-Proto', 'https')
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'HttpOnly'))
+            .expect(shouldSetCookieWithAttribute('connect.sid', 'Secure'))
+            .expect(200, done);
+        });
 
         it('should default to a browser-session length cookie', function(done){
           request(createServer({ cookie: { path: '/admin' } }))
-          .get('/admin')
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
-          .expect(200, done)
-        })
+            .get('/admin')
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
+            .expect(200, done);
+        });
 
         it('should Set-Cookie only once for browser-session cookies', function(done){
-          var server = createServer({ cookie: { path: '/admin' } })
+          var server = createServer({ cookie: { path: '/admin' } });
 
           request(server)
-          .get('/admin/foo')
-          .expect(shouldSetCookie('connect.sid'))
-          .expect(200, function (err, res) {
-            if (err) return done(err)
-            request(server)
-            .get('/admin')
-            .set('Cookie', cookie(res))
-            .expect(shouldNotHaveHeader('Set-Cookie'))
-            .expect(200, done)
-          });
-        })
+            .get('/admin/foo')
+            .expect(shouldSetCookie('connect.sid'))
+            .expect(200, function (err, res) {
+              if (err) return done(err);
+              request(server)
+                .get('/admin')
+                .set('Cookie', cookie(res))
+                .expect(shouldNotHaveHeader('Set-Cookie'))
+                .expect(200, done);
+            });
+        });
 
         it('should override defaults', function(done){
           var server = createServer({ cookie: { path: '/admin', httpOnly: false, secure: true, maxAge: 5000 } }, function (req, res) {
-            req.session.cookie.secure = false
-            res.end()
-          })
+            req.session.cookie.secure = false;
+            res.end();
+          });
 
           request(server)
-          .get('/admin')
-          .expect(shouldSetCookieWithAttribute('connect.sid', 'Expires'))
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'HttpOnly'))
-          .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'Path', '/admin'))
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
-          .expect(200, done)
-        })
+            .get('/admin')
+            .expect(shouldSetCookieWithAttribute('connect.sid', 'Expires'))
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'HttpOnly'))
+            .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'Path', '/admin'))
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
+            .expect(200, done);
+        });
 
         it('should preserve cookies set before writeHead is called', function(done){
           var server = createServer(null, function (req, res) {
-            var cookie = new Cookie()
-            res.setHeader('Set-Cookie', cookie.serialize('previous', 'cookieValue'))
-            res.end()
-          })
+            var cookie = new Cookie();
+            res.setHeader('Set-Cookie', cookie.serialize('previous', 'cookieValue'));
+            res.end();
+          });
 
           request(server)
-          .get('/')
-          .expect(shouldSetCookieToValue('previous', 'cookieValue'))
-          .expect(200, done)
-        })
-      })
+            .get('/')
+            .expect(shouldSetCookieToValue('previous', 'cookieValue'))
+            .expect(200, done);
+        });
+      });
 
       describe('.secure', function(){
-        var app
+        var app;
 
         before(function () {
-          app = createRequestListener({ secret: 'keyboard cat', cookie: { secure: true } })
-        })
+          app = createRequestListener({ secret: 'keyboard cat', cookie: { secure: true } });
+        });
 
         it('should set cookie when secure', function (done) {
-          var cert = fs.readFileSync(__dirname + '/fixtures/server.crt', 'ascii')
+          var cert = fs.readFileSync(__dirname + '/fixtures/server.crt', 'ascii');
           var server = https.createServer({
             key: fs.readFileSync(__dirname + '/fixtures/server.key', 'ascii'),
             cert: cert
-          })
+          });
 
-          server.on('request', app)
+          server.on('request', app);
 
-          var agent = new https.Agent({ca: cert})
-          var createConnection = agent.createConnection
+          var agent = new https.Agent({ca: cert});
+          var createConnection = agent.createConnection;
 
           agent.createConnection = function (options) {
-            options.servername = 'express-session.local'
-            return createConnection.call(this, options)
-          }
+            options.servername = 'express-session.local';
+            return createConnection.call(this, options);
+          };
 
-          var req = request(server).get('/')
-          req.agent(agent)
-          req.expect(shouldSetCookie('connect.sid'))
-          req.expect(200, done)
-        })
+          var req = request(server).get('/');
+          req.agent(agent);
+          req.expect(shouldSetCookie('connect.sid'));
+          req.expect(200, done);
+        });
 
         it('should not set-cookie when insecure', function(done){
-          var server = http.createServer(app)
+          var server = http.createServer(app);
 
           request(server)
-          .get('/')
-          .expect(shouldNotHaveHeader('Set-Cookie'))
-          .expect(200, done)
-        })
-      })
+            .get('/')
+            .expect(shouldNotHaveHeader('Set-Cookie'))
+            .expect(200, done);
+        });
+      });
 
       describe('.maxAge', function () {
         before(function (done) {
-          var ctx = this
+          var ctx = this;
 
-          ctx.cookie = ''
+          ctx.cookie = '';
           ctx.server = createServer({ cookie: { maxAge: 2000 } }, function (req, res) {
             switch (++req.session.count) {
               case 1:
-                break
+                break;
               case 2:
-                req.session.cookie.maxAge = 5000
-                break
+                req.session.cookie.maxAge = 5000;
+                break;
               case 3:
-                req.session.cookie.maxAge = 3000000000
-                break
+                req.session.cookie.maxAge = 3000000000;
+                break;
               default:
-                req.session.count = 0
-                break
+                req.session.count = 0;
+                break;
             }
-            res.end(req.session.count.toString())
-          })
+            res.end(req.session.count.toString());
+          });
 
           request(ctx.server)
-          .get('/')
-          .end(function (err, res) {
-            ctx.cookie = res && cookie(res)
-            done(err)
-          })
-        })
+            .get('/')
+            .end(function (err, res) {
+              ctx.cookie = res && cookie(res);
+              done(err);
+            });
+        });
 
         it('should set cookie expires relative to maxAge', function (done) {
           request(this.server)
-          .get('/')
-          .set('Cookie', this.cookie)
-          .expect(shouldSetCookieToExpireIn('connect.sid', 2000))
-          .expect(200, '1', done)
-        })
+            .get('/')
+            .set('Cookie', this.cookie)
+            .expect(shouldSetCookieToExpireIn('connect.sid', 2000))
+            .expect(200, '1', done);
+        });
 
         it('should modify cookie expires when changed', function (done) {
           request(this.server)
-          .get('/')
-          .set('Cookie', this.cookie)
-          .expect(shouldSetCookieToExpireIn('connect.sid', 5000))
-          .expect(200, '2', done)
-        })
+            .get('/')
+            .set('Cookie', this.cookie)
+            .expect(shouldSetCookieToExpireIn('connect.sid', 5000))
+            .expect(200, '2', done);
+        });
 
         it('should modify cookie expires when changed to large value', function (done) {
           request(this.server)
-          .get('/')
-          .set('Cookie', this.cookie)
-          .expect(shouldSetCookieToExpireIn('connect.sid', 3000000000))
-          .expect(200, '3', done)
-        })
-      })
+            .get('/')
+            .set('Cookie', this.cookie)
+            .expect(shouldSetCookieToExpireIn('connect.sid', 3000000000))
+            .expect(200, '3', done);
+        });
+      });
 
       describe('.expires', function(){
         describe('when given a Date', function(){
           it('should set absolute', function(done){
             var server = createServer(null, function (req, res) {
-              req.session.cookie.expires = new Date(0)
-              res.end()
-            })
+              req.session.cookie.expires = new Date(0);
+              res.end();
+            });
 
             request(server)
-            .get('/')
-            .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'Expires', 'Thu, 01 Jan 1970 00:00:00 GMT'))
-            .expect(200, done)
-          })
-        })
+              .get('/')
+              .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'Expires', 'Thu, 01 Jan 1970 00:00:00 GMT'))
+              .expect(200, done);
+          });
+        });
 
         describe('when null', function(){
           it('should be a browser-session cookie', function(done){
             var server = createServer(null, function (req, res) {
-              req.session.cookie.expires = null
-              res.end()
-            })
+              req.session.cookie.expires = null;
+              res.end();
+            });
 
             request(server)
-            .get('/')
-            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
-            .expect(200, done)
-          })
+              .get('/')
+              .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
+              .expect(200, done);
+          });
 
           it('should not reset cookie', function (done) {
             var server = createServer(null, function (req, res) {
@@ -1954,17 +1954,17 @@ describe('session()', function(){
             });
 
             request(server)
-            .get('/')
-            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
-            .expect(200, function (err, res) {
-              if (err) return done(err);
-              request(server)
               .get('/')
-              .set('Cookie', cookie(res))
-              .expect(shouldNotHaveHeader('Set-Cookie'))
-              .expect(200, done)
-            });
-          })
+              .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
+              .expect(200, function (err, res) {
+                if (err) return done(err);
+                request(server)
+                  .get('/')
+                  .set('Cookie', cookie(res))
+                  .expect(shouldNotHaveHeader('Set-Cookie'))
+                  .expect(200, done);
+              });
+          });
 
           it('should not reset cookie when modified', function (done) {
             var server = createServer(null, function (req, res) {
@@ -1974,151 +1974,151 @@ describe('session()', function(){
             });
 
             request(server)
-            .get('/')
-            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
-            .expect(200, function (err, res) {
-              if (err) return done(err);
-              request(server)
               .get('/')
-              .set('Cookie', cookie(res))
-              .expect(shouldNotHaveHeader('Set-Cookie'))
-              .expect(200, done)
-            });
-          })
-        })
-      })
-    })
-  })
+              .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Expires'))
+              .expect(200, function (err, res) {
+                if (err) return done(err);
+                request(server)
+                  .get('/')
+                  .set('Cookie', cookie(res))
+                  .expect(shouldNotHaveHeader('Set-Cookie'))
+                  .expect(200, done);
+              });
+          });
+        });
+      });
+    });
+  });
 
   describe('synchronous store', function(){
     it('should respond correctly on save', function(done){
-      var store = new SyncStore()
+      var store = new SyncStore();
       var server = createServer({ store: store }, function (req, res) {
-        req.session.count = req.session.count || 0
-        req.session.count++
-        res.end('hits: ' + req.session.count)
-      })
+        req.session.count = req.session.count || 0;
+        req.session.count++;
+        res.end('hits: ' + req.session.count);
+      });
 
       request(server)
-      .get('/')
-      .expect(200, 'hits: 1', done)
-    })
+        .get('/')
+        .expect(200, 'hits: 1', done);
+    });
 
     it('should respond correctly on destroy', function(done){
-      var store = new SyncStore()
+      var store = new SyncStore();
       var server = createServer({ store: store, unset: 'destroy' }, function (req, res) {
-        req.session.count = req.session.count || 0
-        var count = ++req.session.count
+        req.session.count = req.session.count || 0;
+        var count = ++req.session.count;
         if (req.session.count > 1) {
-          req.session = null
-          res.write('destroyed\n')
+          req.session = null;
+          res.write('destroyed\n');
         }
-        res.end('hits: ' + count)
-      })
+        res.end('hits: ' + count);
+      });
 
       request(server)
-      .get('/')
-      .expect(200, 'hits: 1', function (err, res) {
-        if (err) return done(err)
-        request(server)
         .get('/')
-        .set('Cookie', cookie(res))
-        .expect(200, 'destroyed\nhits: 2', done)
-      })
-    })
-  })
+        .expect(200, 'hits: 1', function (err, res) {
+          if (err) return done(err);
+          request(server)
+            .get('/')
+            .set('Cookie', cookie(res))
+            .expect(200, 'destroyed\nhits: 2', done);
+        });
+    });
+  });
 
   describe('cookieParser()', function () {
     it('should read from req.cookies', function(done){
       var app = express()
         .use(cookieParser())
-        .use(function(req, res, next){ req.headers.cookie = 'foo=bar'; next() })
+        .use(function(req, res, next){ req.headers.cookie = 'foo=bar'; next(); })
         .use(createSession())
         .use(function(req, res, next){
-          req.session.count = req.session.count || 0
-          req.session.count++
-          res.end(req.session.count.toString())
-        })
+          req.session.count = req.session.count || 0;
+          req.session.count++;
+          res.end(req.session.count.toString());
+        });
 
       request(app)
-      .get('/')
-      .expect(200, '1', function (err, res) {
-        if (err) return done(err)
-        request(app)
         .get('/')
-        .set('Cookie', cookie(res))
-        .expect(200, '2', done)
-      })
-    })
+        .expect(200, '1', function (err, res) {
+          if (err) return done(err);
+          request(app)
+            .get('/')
+            .set('Cookie', cookie(res))
+            .expect(200, '2', done);
+        });
+    });
 
     it('should reject unsigned from req.cookies', function(done){
       var app = express()
         .use(cookieParser())
-        .use(function(req, res, next){ req.headers.cookie = 'foo=bar'; next() })
+        .use(function(req, res, next){ req.headers.cookie = 'foo=bar'; next(); })
         .use(createSession({ key: 'sessid' }))
         .use(function(req, res, next){
-          req.session.count = req.session.count || 0
-          req.session.count++
-          res.end(req.session.count.toString())
-        })
+          req.session.count = req.session.count || 0;
+          req.session.count++;
+          res.end(req.session.count.toString());
+        });
 
       request(app)
-      .get('/')
-      .expect(200, '1', function (err, res) {
-        if (err) return done(err)
-        request(app)
         .get('/')
-        .set('Cookie', 'sessid=' + sid(res))
-        .expect(200, '1', done)
-      })
-    })
+        .expect(200, '1', function (err, res) {
+          if (err) return done(err);
+          request(app)
+            .get('/')
+            .set('Cookie', 'sessid=' + sid(res))
+            .expect(200, '1', done);
+        });
+    });
 
     it('should reject invalid signature from req.cookies', function(done){
       var app = express()
         .use(cookieParser())
-        .use(function(req, res, next){ req.headers.cookie = 'foo=bar'; next() })
+        .use(function(req, res, next){ req.headers.cookie = 'foo=bar'; next(); })
         .use(createSession({ key: 'sessid' }))
         .use(function(req, res, next){
-          req.session.count = req.session.count || 0
-          req.session.count++
-          res.end(req.session.count.toString())
-        })
+          req.session.count = req.session.count || 0;
+          req.session.count++;
+          res.end(req.session.count.toString());
+        });
 
       request(app)
-      .get('/')
-      .expect(200, '1', function (err, res) {
-        if (err) return done(err)
-        var val = cookie(res).replace(/...\./, '.')
-        request(app)
         .get('/')
-        .set('Cookie', val)
-        .expect(200, '1', done)
-      })
-    })
+        .expect(200, '1', function (err, res) {
+          if (err) return done(err);
+          var val = cookie(res).replace(/...\./, '.');
+          request(app)
+            .get('/')
+            .set('Cookie', val)
+            .expect(200, '1', done);
+        });
+    });
 
     it('should read from req.signedCookies', function(done){
       var app = express()
         .use(cookieParser('keyboard cat'))
-        .use(function(req, res, next){ delete req.headers.cookie; next() })
+        .use(function(req, res, next){ delete req.headers.cookie; next(); })
         .use(createSession())
         .use(function(req, res, next){
-          req.session.count = req.session.count || 0
-          req.session.count++
-          res.end(req.session.count.toString())
-        })
+          req.session.count = req.session.count || 0;
+          req.session.count++;
+          res.end(req.session.count.toString());
+        });
 
       request(app)
-      .get('/')
-      .expect(200, '1', function (err, res) {
-        if (err) return done(err)
-        request(app)
         .get('/')
-        .set('Cookie', cookie(res))
-        .expect(200, '2', done)
-      })
-    })
-  })
-})
+        .expect(200, '1', function (err, res) {
+          if (err) return done(err);
+          request(app)
+            .get('/')
+            .set('Cookie', cookie(res))
+            .expect(200, '2', done);
+        });
+    });
+  });
+});
 
 function cookie(res) {
   var setCookie = res.headers['set-cookie'];
@@ -2126,231 +2126,231 @@ function cookie(res) {
 }
 
 function createServer (options, respond) {
-  var fn = respond
-  var opts = options
-  var server = http.createServer()
+  var fn = respond;
+  var opts = options;
+  var server = http.createServer();
 
   // setup, options, respond
   if (typeof arguments[0] === 'function') {
-    opts = arguments[1]
-    fn = arguments[2]
+    opts = arguments[1];
+    fn = arguments[2];
 
-    server.on('request', arguments[0])
+    server.on('request', arguments[0]);
   }
 
-  return server.on('request', createRequestListener(opts, fn))
+  return server.on('request', createRequestListener(opts, fn));
 }
 
 function createRequestListener(opts, fn) {
-  var _session = createSession(opts)
-  var respond = fn || end
+  var _session = createSession(opts);
+  var respond = fn || end;
 
   return function onRequest(req, res) {
-    var server = this
+    var server = this;
 
     _session(req, res, function (err) {
       if (err && !res._header) {
-        res.statusCode = err.status || 500
-        res.end(err.message)
-        return
+        res.statusCode = err.status || 500;
+        res.end(err.message);
+        return;
       }
 
       if (err) {
-        server.emit('error', err)
-        return
+        server.emit('error', err);
+        return;
       }
 
-      respond(req, res)
-    })
-  }
+      respond(req, res);
+    });
+  };
 }
 
 function createSession(opts) {
-  var options = opts || {}
+  var options = opts || {};
 
   if (!('cookie' in options)) {
-    options.cookie = { maxAge: 60 * 1000 }
+    options.cookie = { maxAge: 60 * 1000 };
   }
 
   if (!('secret' in options)) {
-    options.secret = 'keyboard cat'
+    options.secret = 'keyboard cat';
   }
 
-  return session(options)
+  return session(options);
 }
 
 function end(req, res) {
-  res.end()
+  res.end();
 }
 
 function expires (res) {
-  var header = cookie(res)
-  return header && parseSetCookie(header).expires
+  var header = cookie(res);
+  return header && parseSetCookie(header).expires;
 }
 
 function mountAt (path) {
   return function (req, res) {
     if (req.url.indexOf(path) === 0) {
-      req.originalUrl = req.url
-      req.url = req.url.slice(path.length)
+      req.originalUrl = req.url;
+      req.url = req.url.slice(path.length);
     }
-  }
+  };
 }
 
 function parseSetCookie (header) {
-  var match
-  var pairs = []
-  var pattern = /\s*([^=;]+)(?:=([^;]*);?|;|$)/g
+  var match;
+  var pairs = [];
+  var pattern = /\s*([^=;]+)(?:=([^;]*);?|;|$)/g;
 
   while ((match = pattern.exec(header))) {
-    pairs.push({ name: match[1], value: match[2] })
+    pairs.push({ name: match[1], value: match[2] });
   }
 
-  var cookie = pairs.shift()
+  var cookie = pairs.shift();
 
   for (var i = 0; i < pairs.length; i++) {
-    match = pairs[i]
-    cookie[match.name.toLowerCase()] = (match.value || true)
+    match = pairs[i];
+    cookie[match.name.toLowerCase()] = (match.value || true);
   }
 
-  return cookie
+  return cookie;
 }
 
 function shouldNotHaveHeader(header) {
   return function (res) {
-    assert.ok(!(header.toLowerCase() in res.headers), 'should not have ' + header + ' header')
-  }
+    assert.ok(!(header.toLowerCase() in res.headers), 'should not have ' + header + ' header');
+  };
 }
 
 function shouldNotSetSessionInStore(store) {
-  var _set = store.set
-  var count = 0
+  var _set = store.set;
+  var count = 0;
 
   store.set = function set () {
-    count++
-    return _set.apply(this, arguments)
-  }
+    count++;
+    return _set.apply(this, arguments);
+  };
 
   return function () {
-    assert.ok(count === 0, 'should not set session in store')
-  }
+    assert.ok(count === 0, 'should not set session in store');
+  };
 }
 
 function shouldSetCookie (name) {
   return function (res) {
-    var header = cookie(res)
-    var data = header && parseSetCookie(header)
-    assert.ok(header, 'should have a cookie header')
-    assert.strictEqual(data.name, name, 'should set cookie ' + name)
-  }
+    var header = cookie(res);
+    var data = header && parseSetCookie(header);
+    assert.ok(header, 'should have a cookie header');
+    assert.strictEqual(data.name, name, 'should set cookie ' + name);
+  };
 }
 
 function shouldSetCookieToDifferentSessionId (id) {
   return function (res) {
-    assert.notStrictEqual(sid(res), id)
-  }
+    assert.notStrictEqual(sid(res), id);
+  };
 }
 
 function shouldSetCookieToExpireIn (name, delta) {
   return function (res) {
-    var header = cookie(res)
-    var data = header && parseSetCookie(header)
-    assert.ok(header, 'should have a cookie header')
-    assert.strictEqual(data.name, name, 'should set cookie ' + name)
-    assert.ok(('expires' in data), 'should set cookie with attribute Expires')
-    assert.ok(('date' in res.headers), 'should have a date header')
-    assert.strictEqual((Date.parse(data.expires) - Date.parse(res.headers.date)), delta, 'should set cookie ' + name + ' to expire in ' + delta + ' ms')
-  }
+    var header = cookie(res);
+    var data = header && parseSetCookie(header);
+    assert.ok(header, 'should have a cookie header');
+    assert.strictEqual(data.name, name, 'should set cookie ' + name);
+    assert.ok(('expires' in data), 'should set cookie with attribute Expires');
+    assert.ok(('date' in res.headers), 'should have a date header');
+    assert.strictEqual((Date.parse(data.expires) - Date.parse(res.headers.date)), delta, 'should set cookie ' + name + ' to expire in ' + delta + ' ms');
+  };
 }
 
 function shouldSetCookieToValue (name, val) {
   return function (res) {
-    var header = cookie(res)
-    var data = header && parseSetCookie(header)
-    assert.ok(header, 'should have a cookie header')
-    assert.strictEqual(data.name, name, 'should set cookie ' + name)
-    assert.strictEqual(data.value, val, 'should set cookie ' + name + ' to ' + val)
-  }
+    var header = cookie(res);
+    var data = header && parseSetCookie(header);
+    assert.ok(header, 'should have a cookie header');
+    assert.strictEqual(data.name, name, 'should set cookie ' + name);
+    assert.strictEqual(data.value, val, 'should set cookie ' + name + ' to ' + val);
+  };
 }
 
 function shouldSetCookieWithAttribute (name, attrib) {
   return function (res) {
-    var header = cookie(res)
-    var data = header && parseSetCookie(header)
-    assert.ok(header, 'should have a cookie header')
-    assert.strictEqual(data.name, name, 'should set cookie ' + name)
-    assert.ok((attrib.toLowerCase() in data), 'should set cookie with attribute ' + attrib)
-  }
+    var header = cookie(res);
+    var data = header && parseSetCookie(header);
+    assert.ok(header, 'should have a cookie header');
+    assert.strictEqual(data.name, name, 'should set cookie ' + name);
+    assert.ok((attrib.toLowerCase() in data), 'should set cookie with attribute ' + attrib);
+  };
 }
 
 function shouldSetCookieWithAttributeAndValue (name, attrib, value) {
   return function (res) {
-    var header = cookie(res)
-    var data = header && parseSetCookie(header)
-    assert.ok(header, 'should have a cookie header')
-    assert.strictEqual(data.name, name, 'should set cookie ' + name)
-    assert.ok((attrib.toLowerCase() in data), 'should set cookie with attribute ' + attrib)
-    assert.strictEqual(data[attrib.toLowerCase()], value, 'should set cookie with attribute ' + attrib + ' set to ' + value)
-  }
+    var header = cookie(res);
+    var data = header && parseSetCookie(header);
+    assert.ok(header, 'should have a cookie header');
+    assert.strictEqual(data.name, name, 'should set cookie ' + name);
+    assert.ok((attrib.toLowerCase() in data), 'should set cookie with attribute ' + attrib);
+    assert.strictEqual(data[attrib.toLowerCase()], value, 'should set cookie with attribute ' + attrib + ' set to ' + value);
+  };
 }
 
 function shouldSetCookieWithoutAttribute (name, attrib) {
   return function (res) {
-    var header = cookie(res)
-    var data = header && parseSetCookie(header)
-    assert.ok(header, 'should have a cookie header')
-    assert.strictEqual(data.name, name, 'should set cookie ' + name)
-    assert.ok(!(attrib.toLowerCase() in data), 'should set cookie without attribute ' + attrib)
-  }
+    var header = cookie(res);
+    var data = header && parseSetCookie(header);
+    assert.ok(header, 'should have a cookie header');
+    assert.strictEqual(data.name, name, 'should set cookie ' + name);
+    assert.ok(!(attrib.toLowerCase() in data), 'should set cookie without attribute ' + attrib);
+  };
 }
 
 function shouldSetSessionInStore(store) {
-  var _set = store.set
-  var count = 0
+  var _set = store.set;
+  var count = 0;
 
   store.set = function set () {
-    count++
-    return _set.apply(this, arguments)
-  }
+    count++;
+    return _set.apply(this, arguments);
+  };
 
   return function () {
-    assert.ok(count === 1, 'should set session in store')
-  }
+    assert.ok(count === 1, 'should set session in store');
+  };
 }
 
 function sid (res) {
-  var header = cookie(res)
-  var data = header && parseSetCookie(header)
-  var value = data && unescape(data.value)
-  var sid = value && value.substring(2, value.indexOf('.'))
-  return sid || undefined
+  var header = cookie(res);
+  var data = header && parseSetCookie(header);
+  var value = data && unescape(data.value);
+  var sid = value && value.substring(2, value.indexOf('.'));
+  return sid || undefined;
 }
 
 function writePatch (res) {
-  var _end = res.end
-  var _write = res.write
-  var ended = false
+  var _end = res.end;
+  var _write = res.write;
+  var ended = false;
 
   res.end = function end() {
-    ended = true
-    return _end.apply(this, arguments)
-  }
+    ended = true;
+    return _end.apply(this, arguments);
+  };
 
   res.write = function write() {
     if (ended) {
-      throw new Error('write after end')
+      throw new Error('write after end');
     }
 
-    return _write.apply(this, arguments)
-  }
+    return _write.apply(this, arguments);
+  };
 }
 
 function SyncStore () {
-  session.Store.call(this)
-  this.sessions = Object.create(null)
+  session.Store.call(this);
+  this.sessions = Object.create(null);
 }
 
-util.inherits(SyncStore, session.Store)
+util.inherits(SyncStore, session.Store);
 
 SyncStore.prototype.destroy = function destroy(sid, callback) {
   delete this.sessions[sid];


### PR DESCRIPTION
I found inconsistent code styling across most of the javascript files in regards to semi-colons. Some statements ending in semi-colons, others were not. For example:

`var cookie = require('cookie');`
 `var crypto = require('crypto')` 

  This is a pull request to create consistency across the project. This change includes an eslint rule that applies a warning if a semicolon is not used at the end of a statement.

I suppose a conversation could be had where it is determined that **no** semi-colons are used. In any case, a rule should be applied and consistency should be maintained.