### PR TITLE
Fix bug in cookie store

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Fix error passing `data` option to `Cookie` constructor
+  * Fix uncaught error from bad session data
 
 1.16.0 / 2019-04-10
 ===================

--- a/session/memory.js
+++ b/session/memory.js
@@ -171,14 +171,16 @@ function getSession(sessionId) {
   // parse
   sess = JSON.parse(sess)
 
-  var expires = typeof sess.cookie.expires === 'string'
-    ? new Date(sess.cookie.expires)
-    : sess.cookie.expires
+  if (sess.cookie) {
+    var expires = typeof sess.cookie.expires === 'string'
+      ? new Date(sess.cookie.expires)
+      : sess.cookie.expires
 
-  // destroy expired session
-  if (expires && expires <= Date.now()) {
-    delete this.sessions[sessionId]
-    return
+    // destroy expired session
+    if (expires && expires <= Date.now()) {
+      delete this.sessions[sessionId]
+      return
+    }
   }
 
   return sess

--- a/test/session.js
+++ b/test/session.js
@@ -610,6 +610,31 @@ describe('session()', function(){
     })
   })
 
+  describe('when session without cookie property in store', function () {
+    it('should pass error from inflate', function (done) {
+      var count = 0
+      var store = new session.MemoryStore()
+      var server = createServer({ store: store }, function (req, res) {
+        req.session.num = req.session.num || ++count
+        res.end('session ' + req.session.num)
+      })
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, 'session 1', function (err, res) {
+        if (err) return done(err)
+        store.set(sid(res), { foo: 'bar' }, function (err) {
+          if (err) return done(err)
+          request(server)
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(500, /Cannot read property/, done)
+        })
+      })
+    })
+  })
+
   describe('proxy option', function(){
     describe('when enabled', function(){
       var server


### PR DESCRIPTION
I’m using SOA (Service Oriented Architecture) application. There I’m having different services that wroted on different languages. For store session I’m using Redis. In PHP and others applications I'm implementing express-session like handlers for share sessions between the services.

But I’m also using third party services, and they can generate broken session record without cookie section. If this section is missed, then all my Node.js applications are went down with error:

```js
node_modules/express-session/session/store.js:87
var expires = sess.cookie.expires
                         ^
TypeError: Cannot read property 'expires' of undefined at RedisStore.Store.createSession
```