### PR TITLE
Use 'req.sessionStore' instead of directly using 'store' object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ function session(options) {
       if (shouldDestroy(req)) {
         // destroy session
         debug('destroying');
-        store.destroy(req.sessionID, function ondestroy(err) {
+        req.sessionStore.destroy(req.sessionID, function ondestroy(err) {
           if (err) {
             defer(next, err);
           }
@@ -458,7 +458,7 @@ function session(options) {
 
     // generate the session object
     debug('fetching %s', req.sessionID);
-    store.get(req.sessionID, function(err, sess){
+    req.sessionStore.get(req.sessionID, function(err, sess){
       // error handling
       if (err) {
         debug('error %j', err);


### PR DESCRIPTION
## Description
Use `req.sessionStore` instead of directly using `store` object. This gives flexibility to inject additional parameters like `req` to `store.get` and `store.destroy` via custom traps using [JavaScript Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) without changing the interface of the `Store`.

## Motivation and Context
We want to pass `req` object down to the methods of our `Store` implementation. `store.set` method can access it from `session.req` but it is not available in `store.get` and `store.destroy` methods.

One workaround we found is to leverage setter of `req.sessionStore` to create [JavaScript Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) of the `store` object. This proxy has traps for `store.get` and `store.set` and it adds the `req` object as a parameter to the function call.

To make this work we need changes in this module to use `req.sessionStore.get` and `req.sessionStore.destroy` methods so that the proxy object is used.