### PR TITLE
TypeError: Cannot set property data of #<Object> which has only a getter fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix error passing `data` option to `Cookie` constructor
+
 1.16.0 / 2019-04-10
 ===================
 

--- a/session/cookie.js
+++ b/session/cookie.js
@@ -33,7 +33,9 @@ var Cookie = module.exports = function Cookie(options) {
     }
 
     for (var key in options) {
-      this[key] = options[key]
+      if (key !== 'data') {
+        this[key] = options[key]
+      }
     }
   }
 

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -44,6 +44,15 @@ describe('new Cookie()', function () {
       assert.throws(function () { new Cookie(function () {}) }, /argument options/)
     })
 
+    it('should ignore "data" option', function () {
+      var cookie = new Cookie({ data: { foo: 'bar' }, path: '/foo' })
+
+      assert.strictEqual(typeof cookie, 'object')
+      assert.strictEqual(typeof cookie.data, 'object')
+      assert.strictEqual(cookie.data.path, '/foo')
+      assert.notStrictEqual(cookie.data.foo, 'bar')
+    })
+
     describe('expires', function () {
       it('should set expires', function () {
         var expires = new Date(Date.now() + 60000)


### PR DESCRIPTION
Hello. In new release you have an error:
`TypeError: Cannot set property data of #<Object> which has only a getter`

So, this happened because you've changed this code 
![image](https://user-images.githubusercontent.com/22622869/55954592-847b1300-5c78-11e9-8236-59b25d942f30.png)
But in your `cookie.js` file `strict mode` is enabled. That is the reason why JS throws an error.
So I think the better way is to define setter for data field in prototype.