### PR TITLE
originalMaxAge should always be restored.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix restoring `cookie.originalMaxAge` when store returns `Date`
   * deps: parseurl@~1.3.3
 
 1.16.1 / 2019-04-11

--- a/session/store.js
+++ b/session/store.js
@@ -91,11 +91,11 @@ Store.prototype.createSession = function(req, sess){
 
   if (typeof expires === 'string') {
     // convert expires to a Date object,
-    // keeping originalMaxAge intact
     sess.cookie.expires = new Date(expires)
-    sess.cookie.originalMaxAge = originalMaxAge
   }
 
+  // keeping originalMaxAge intact
+  sess.cookie.originalMaxAge = originalMaxAge
   req.session = new Session(req, sess);
   return req.session;
 };

--- a/test/support/smart-store.js
+++ b/test/support/smart-store.js
@@ -1,0 +1,54 @@
+'use strict'
+
+var session = require('../../')
+var util = require('util')
+
+/* istanbul ignore next */
+var defer = typeof setImmediate === 'function'
+  ? setImmediate
+  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
+
+module.exports = SmartStore
+
+function SmartStore () {
+  session.Store.call(this)
+  this.sessions = Object.create(null)
+}
+
+util.inherits(SmartStore, session.Store)
+
+SmartStore.prototype.destroy = function destroy (sid, callback) {
+  delete this.sessions[sid]
+  defer(callback, null)
+}
+
+SmartStore.prototype.get = function get (sid, callback) {
+  var sess = this.sessions[sid]
+
+  if (!sess) {
+    return
+  }
+
+  // parse
+  sess = JSON.parse(sess)
+
+  if (sess.cookie) {
+    // expand expires into Date object
+    sess.cookie.expires = typeof sess.cookie.expires === 'string'
+      ? new Date(sess.cookie.expires)
+      : sess.cookie.expires
+
+    // destroy expired session
+    if (sess.cookie.expires && sess.cookie.expires <= Date.now()) {
+      delete this.sessions[sid]
+      sess = null
+    }
+  }
+
+  defer(callback, null, sess)
+}
+
+SmartStore.prototype.set = function set (sid, sess, callback) {
+  this.sessions[sid] = JSON.stringify(sess)
+  defer(callback, null)
+}


### PR DESCRIPTION
If `expires` is a Date, then originalMaxAge is not restored and session is not being rolled.