### PR TITLE
Possible fix for #549

### DIFF
--- a/index.js
+++ b/index.js
@@ -522,22 +522,25 @@ function getcookie(req, name, secrets) {
 
   // read from cookie header
   if (header) {
-    var cookies = cookie.parse(header);
+    var cookies = cookie.parse(header, {
+      decode: (localRaw) => {
+        if (localRaw.substr(0, 2) === 's:') {
+          const localVal = unsigncookie(localRaw.slice(2), secrets);
 
-    raw = cookies[name];
+          if (localVal === false) {
+            debug('cookie signature invalid');
+            return null;
+          }
 
-    if (raw) {
-      if (raw.substr(0, 2) === 's:') {
-        val = unsigncookie(raw.slice(2), secrets);
-
-        if (val === false) {
-          debug('cookie signature invalid');
-          val = undefined;
+          return localVal;
+        } else {
+          debug('cookie unsigned')
+          return localRaw;
         }
-      } else {
-        debug('cookie unsigned')
-      }
-    }
+      },
+    });
+
+    val = cookies[name];
   }
 
   // back-compat read from cookieParser() signedCookies data

--- a/index.js
+++ b/index.js
@@ -524,6 +524,8 @@ function getcookie(req, name, secrets) {
   if (header) {
     var cookies = cookie.parse(header, {
       decode: (localRaw) => {
+        localRaw = decodeURIComponent(localRaw);
+
         if (localRaw.substr(0, 2) === 's:') {
           const localVal = unsigncookie(localRaw.slice(2), secrets);
 


### PR DESCRIPTION
Cookie value decoding should be made in the dedicated decode function provided by npm "cookie".

This may fix issue #549 since a duplicated cookie coming from a domain with a different secret wont be decoded, and so replaced by the one from the good domain.

As a test you can check this behavior with the following code snipet: 

```
cookie.parse('test=bla; test=blou', {decode: _ => _ === 'bla' ? 'bla' : 'blou'});
// { test: 'bla' }

cookie.parse('test=bla; test=blou', {decode: _ => _ === 'bla' ? null : 'blou'});
// { test: 'blou' }
```