### PR TITLE
Correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ For an example implementation view the [connect-redis](http://github.com/visionm
 
 **Optional**
 
-This optional method is used to get all sessions in the store as an array. The
+This optional method is used to get all sessions in the store as an array or as an object with type `{[sessionId]: sessionObject}`. The
 `callback` should be called as `callback(error, sessions)`.
 
 ### store.destroy(sid, callback)


### PR DESCRIPTION
In https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38783 @armanio123 points out that in MemoryStore, MemoryStore.all(callback) calls the callback with signiture callback(error, sessions) where sessions is an Object, but as stated in the README "sessions" should be an array.

>store.all(callback)
>Optional
>
>This optional method is used to get all sessions in the store as an **array**. The callback should be called as callback(error, sessions).

Indeed the two most popular [connect-redis](https://github.com/tj/connect-redis) and [connect-mongo](https://github.com/jdesboeufs/connect-mongo) follow the documentation and call with an Array instead of an Object.

See here: https://github.com/jdesboeufs/connect-mongo/blob/master/src/index.js#L365 and
https://github.com/tj/connect-redis/blob/master/lib/connect-redis.js#L101

In an effort to not add a breaking change to this library, instead of changing the implementation of MemoryStore.all, I have created this pull request to change the README to include both implementations.
