### PR TITLE
Enabling stores to opt into seeing the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ all the elements will be considered when verifying the signature in requests.
 
 The session store instance, defaults to a new `MemoryStore` instance.
 
+##### passReqToStore
+
+Pass the request object to required and optional store methods.
+
+By default, the request object is not passed to store methods.
+
 ##### unset
 
 Control the result of unsetting `req.session` (through `delete`, setting to `null`,
@@ -347,6 +353,11 @@ req.session.reload(function(err) {
   // session updated
 })
 ```
+
+#### Session.load(sid, callback)
+
+Loads the the session data for the given `sid` from the store and re-populates the
+`req.session` object. Once complete, the `callback` will be invoked.
 
 #### Session.save(callback)
 
@@ -420,6 +431,14 @@ To get the ID of the loaded session, access the request property
 `req.sessionID`. This is simply a read-only value set when a session
 is loaded/created.
 
+### req.sessionOptions
+
+To get the options of the session, access the request property
+`req.sessionOptions`.
+
+**NOTE** For performance reasons, this is the original global options object.
+Changes to it would take effect for all requests in an undefined manner.
+
 ## Session Store Implementation
 
 Every session store _must_ be an `EventEmitter` and implement specific
@@ -449,6 +468,10 @@ This required method is used to destroy/delete a session from the store given
 a session ID (`sid`). The `callback` should be called as `callback(error)` once
 the session is destroyed.
 
+The request is passed into the `req` argument only if the session's options
+have `passReqToStore` set to `true`. A store wishing to operate in either mode
+should check whether the second argument is a function or an object.
+
 ### store.clear(callback)
 
 **Optional**
@@ -474,6 +497,10 @@ The `session` argument should be a session if found, otherwise `null` or
 `undefined` if the session was not found (and there was no error). A special
 case is made when `error.code === 'ENOENT'` to act like `callback(null, null)`.
 
+The request is passed into the `req` argument only if the session's options
+have `passReqToStore` set to `true`. A store wishing to operate in either mode
+should check whether the second argument is a function or an object.
+
 ### store.set(sid, session, [req], callback)
 
 **Required**
@@ -481,6 +508,10 @@ case is made when `error.code === 'ENOENT'` to act like `callback(null, null)`.
 This required method is used to upsert a session into the store given a
 session ID (`sid`) and session (`session`) object. The callback should be
 called as `callback(error)` once the session has been set in the store.
+
+The request is passed into the `req` argument only if the session's options
+have `passReqToStore` set to `true`. A store wishing to operate in either mode
+should check whether the third argument is a function or an object.
 
 ### store.touch(sid, session, [req], callback)
 
@@ -493,6 +524,10 @@ called as `callback(error)` once the session has been touched.
 This is primarily used when the store will automatically delete idle sessions
 and this method is used to signal to the store the given session is active,
 potentially resetting the idle timer.
+
+The request is passed into the `req` argument only if the session's options
+have `passReqToStore` set to `true`. A store wishing to operate in either mode
+should check whether the third argument is a function or an object.
 
 ## Compatible Session Stores
 

--- a/README.md
+++ b/README.md
@@ -278,12 +278,6 @@ all the elements will be considered when verifying the signature in requests.
 
 The session store instance, defaults to a new `MemoryStore` instance.
 
-##### passReqToStore
-
-Pass the request object to required and optional store methods.
-
-By default, the request object is not passed to store methods.
-
 ##### unset
 
 Control the result of unsetting `req.session` (through `delete`, setting to `null`,
@@ -431,14 +425,6 @@ To get the ID of the loaded session, access the request property
 `req.sessionID`. This is simply a read-only value set when a session
 is loaded/created.
 
-### req.sessionOptions
-
-To get the options of the session, access the request property
-`req.sessionOptions`.
-
-**NOTE** For performance reasons, this is the original global options object.
-Changes to it would take effect for all requests in an undefined manner.
-
 ## Session Store Implementation
 
 Every session store _must_ be an `EventEmitter` and implement specific
@@ -468,9 +454,7 @@ This required method is used to destroy/delete a session from the store given
 a session ID (`sid`). The `callback` should be called as `callback(error)` once
 the session is destroyed.
 
-The request is passed into the `req` argument only if the session's options
-have `passReqToStore` set to `true`. A store wishing to operate in either mode
-should check whether the second argument is a function or an object.
+The request is passed into the `req` argument only if the store sets `store.passReq` to `true`.
 
 ### store.clear(callback)
 
@@ -497,9 +481,7 @@ The `session` argument should be a session if found, otherwise `null` or
 `undefined` if the session was not found (and there was no error). A special
 case is made when `error.code === 'ENOENT'` to act like `callback(null, null)`.
 
-The request is passed into the `req` argument only if the session's options
-have `passReqToStore` set to `true`. A store wishing to operate in either mode
-should check whether the second argument is a function or an object.
+The request is passed into the `req` argument only if the store sets `store.passReq` to `true`.
 
 ### store.set(sid, session, [req], callback)
 
@@ -509,9 +491,7 @@ This required method is used to upsert a session into the store given a
 session ID (`sid`) and session (`session`) object. The callback should be
 called as `callback(error)` once the session has been set in the store.
 
-The request is passed into the `req` argument only if the session's options
-have `passReqToStore` set to `true`. A store wishing to operate in either mode
-should check whether the third argument is a function or an object.
+The request is passed into the `req` argument only if the store sets `store.passReq` to `true`.
 
 ### store.touch(sid, session, [req], callback)
 
@@ -525,9 +505,16 @@ This is primarily used when the store will automatically delete idle sessions
 and this method is used to signal to the store the given session is active,
 potentially resetting the idle timer.
 
-The request is passed into the `req` argument only if the session's options
-have `passReqToStore` set to `true`. A store wishing to operate in either mode
-should check whether the third argument is a function or an object.
+The request is passed into the `req` argument only if the store sets `store.passReq` to `true`.
+
+### store.passReq
+
+**Optional**
+
+A property determining whether the request is passed to the store in the other methods.
+Defaults to `false` if left undefined.
+
+A store wishing to operate in either mode (in order to maintain compatibility with earlier versions of this package) may set this to `true`, but check the arguments given to each method.
 
 ## Compatible Session Stores
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ For an example implementation view the [connect-redis](http://github.com/visionm
 This optional method is used to get all sessions in the store as an array. The
 `callback` should be called as `callback(error, sessions)`.
 
-### store.destroy(sid, callback)
+### store.destroy(sid, [req], callback)
 
 **Required**
 
@@ -463,7 +463,7 @@ This optional method is used to delete all sessions from the store. The
 This optional method is used to get the count of all sessions in the store.
 The `callback` should be called as `callback(error, len)`.
 
-### store.get(sid, callback)
+### store.get(sid, [req], callback)
 
 **Required**
 
@@ -474,7 +474,7 @@ The `session` argument should be a session if found, otherwise `null` or
 `undefined` if the session was not found (and there was no error). A special
 case is made when `error.code === 'ENOENT'` to act like `callback(null, null)`.
 
-### store.set(sid, session, callback)
+### store.set(sid, session, [req], callback)
 
 **Required**
 
@@ -482,7 +482,7 @@ This required method is used to upsert a session into the store given a
 session ID (`sid`) and session (`session`) object. The callback should be
 called as `callback(error)` once the session has been set in the store.
 
-### store.touch(sid, session, callback)
+### store.touch(sid, session, [req], callback)
 
 **Recommended**
 

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ function session(options) {
   var storeImplementsTouch = typeof store.touch === 'function';
   var storeImplementsRequestAtGet = store.get.length >= 3;
   var storeImplementsRequestAtDestroy = store.destroy.length >= 3;
-  var storeImplementsRequestAtTouch = storeImplementsTouch && store.destroy.length >= 4;
+  var storeImplementsRequestAtTouch = storeImplementsTouch && store.touch.length >= 4;
 
   // register event listeners for the store to track readiness
   var storeReady = true

--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@ var defer = typeof setImmediate === 'function'
  * @param {Boolean} [options.saveUninitialized] Save uninitialized sessions to the store
  * @param {String|Array} [options.secret] Secret for signing session ID
  * @param {Object} [options.store=MemoryStore] Session store
- * @param {Boolean} [options.passReqToStore] Pass the request to store methods
  * @param {String} [options.unset]
  * @return {Function} middleware
  * @public
@@ -99,9 +98,6 @@ function session(options) {
 
   // get the session store
   var store = opts.store || new MemoryStore()
-
-  var passReqToStore = opts.passReqToStore;
-
   // get the trust proxy setting
   var trustProxy = opts.proxy
 
@@ -218,7 +214,7 @@ function session(options) {
         if (!sess) return fn();
         fn(null, store.createSession(req, sess))
       };
-      if (passReqToStore) {
+      if (store.passReq) {
         store.get(sid, req, getCallback);
       } else {
         store.get(sid, getCallback);
@@ -236,8 +232,6 @@ function session(options) {
 
     // expose store
     req.sessionStore = store;
-    // expose session options
-    req.sessionOptions = opts;
 
     // get the session ID from the cookie
     var cookieId = req.sessionID = getcookie(req, name, secrets);
@@ -338,7 +332,7 @@ function session(options) {
           writeend();
         }
 
-        if (passReqToStore) {
+        if (store.passReq) {
           store.destroy(req.sessionID, req, ondestroy);
         } else {
           store.destroy(req.sessionID, ondestroy);
@@ -381,7 +375,7 @@ function session(options) {
           writeend();
         }
 
-        if (passReqToStore) {
+        if (store.passReq) {
           store.touch(req.sessionID, req.session, req, ontouch);
         } else {
           store.touch(req.sessionID, req.session, ontouch);
@@ -532,7 +526,7 @@ function session(options) {
 
       next()
     }
-    if (passReqToStore) {
+    if (store.passReq) {
       store.get(req.sessionID, req, getHandler);
     } else {
       store.get(req.sessionID, getHandler);

--- a/session/session.js
+++ b/session/session.js
@@ -69,7 +69,7 @@ defineMethod(Session.prototype, 'resetMaxAge', function resetMaxAge() {
  */
 
 defineMethod(Session.prototype, 'save', function save(fn) {
-  if (this.req.sessionOptions.passReqToStore) {
+  if (this.req.sessionStore.passReq) {
     this.req.sessionStore.set(this.id, this, this.req, fn || function(){});
   } else {
     this.req.sessionStore.set(this.id, this, fn || function(){});
@@ -99,7 +99,7 @@ defineMethod(Session.prototype, 'reload', function reload(fn) {
     store.createSession(req, sess);
     fn();
   };
-  if (this.req.sessionOptions.passReqToStore) {
+  if (store.passReq) {
     store.get(this.id, req, getCallback);
   } else {
     store.get(this.id, getCallback);
@@ -117,7 +117,7 @@ defineMethod(Session.prototype, 'reload', function reload(fn) {
 
 defineMethod(Session.prototype, 'destroy', function destroy(fn) {
   delete this.req.session;
-  if (this.req.sessionOptions.passReqToStore) {
+  if (this.req.sessionStore.passReq) {
     this.req.sessionStore.destroy(this.id, this.req, fn);
   } else {
     this.req.sessionStore.destroy(this.id, fn);

--- a/session/session.js
+++ b/session/session.js
@@ -69,7 +69,11 @@ defineMethod(Session.prototype, 'resetMaxAge', function resetMaxAge() {
  */
 
 defineMethod(Session.prototype, 'save', function save(fn) {
-  this.req.sessionStore.set(this.id, this, fn || function(){});
+  if (this.req.sessionStore.set.length >= 4) {
+    this.req.sessionStore.set(this.id, this, this.req, fn || function(){});
+  } else {
+    this.req.sessionStore.set(this.id, this, fn || function(){});
+  }
   return this;
 });
 

--- a/session/store.js
+++ b/session/store.js
@@ -49,29 +49,15 @@ util.inherits(Store, EventEmitter)
 
 Store.prototype.regenerate = function(req, fn){
   var self = this;
-  this.destroy(req.sessionID, function(err){
+  var destroyCallback = function(err){
     self.generate(req);
     fn(err);
-  });
-};
-
-/**
- * Load a `Session` instance via the given `sid`
- * and invoke the callback `fn(err, sess)`.
- *
- * @param {String} sid
- * @param {Function} fn
- * @api public
- */
-
-Store.prototype.load = function(sid, fn){
-  var self = this;
-  this.get(sid, function(err, sess){
-    if (err) return fn(err);
-    if (!sess) return fn();
-    var req = { sessionID: sid, sessionStore: self };
-    fn(null, self.createSession(req, sess))
-  });
+  };
+  if (req.sessionOptions.passReqToStore) {
+    this.destroy(req.sessionID, req, destroyCallback);
+  } else {
+    this.destroy(req.sessionID, destroyCallback);
+  }
 };
 
 /**

--- a/session/store.js
+++ b/session/store.js
@@ -53,7 +53,7 @@ Store.prototype.regenerate = function(req, fn){
     self.generate(req);
     fn(err);
   };
-  if (req.sessionOptions.passReqToStore) {
+  if (self.passReq) {
     this.destroy(req.sessionID, req, destroyCallback);
   } else {
     this.destroy(req.sessionID, destroyCallback);

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -62,11 +62,12 @@ describe('new Cookie()', function () {
       })
 
       it('should set maxAge', function () {
-        var expires = new Date(Date.now() + 60000)
+        var now = Date.now()
+        var expires = new Date(now + 60000)
         var cookie = new Cookie({ expires: expires })
 
-        assert.ok(expires.getTime() - Date.now() - 1000 <= cookie.maxAge)
-        assert.ok(expires.getTime() - Date.now() + 1000 >= cookie.maxAge)
+        assert.ok(expires.getTime() - now - 1000 <= cookie.maxAge)
+        assert.ok(expires.getTime() - now + 1000 >= cookie.maxAge)
       })
     })
 

--- a/test/session.js
+++ b/test/session.js
@@ -1585,7 +1585,7 @@ describe('session()', function(){
 
       it('should destroy the previous session when a request is passed', function(done){
         var store = new ReqStore()
-        var server = createServer({ store: store, passReqToStore: true }, function (req, res) {
+        var server = createServer({ store: store }, function (req, res) {
           req.session.destroy(function (err) {
             if (err) res.statusCode = 500
             res.end(String(req.session))
@@ -1625,7 +1625,7 @@ describe('session()', function(){
 
       it('should destroy/replace the previous session when request is passed', function(done){
         var store = new ReqStore()
-        var server = createServer({ store: store, passReqToStore: true }, function (req, res) {
+        var server = createServer({ store: store }, function (req, res) {
           var id = req.session.id
           req.session.regenerate(function (err) {
             if (err) res.statusCode = 500
@@ -1691,7 +1691,7 @@ describe('session()', function(){
 
       it('should reload session from store when request is passed', function (done) {
         var store = new ReqStore()
-        var server = createServer({ store: store, passReqToStore: true }, function (req, res) {
+        var server = createServer({ store: store }, function (req, res) {
           if (req.url === '/') {
             req.session.active = true
             res.end('session created')
@@ -2188,7 +2188,7 @@ describe('session()', function(){
   describe('request supporting store', function(){
     it('should respond correctly on save', function(done){
       var store = new ReqStore()
-      var server = createServer({ store: store, passReqToStore: true }, function (req, res) {
+      var server = createServer({ store: store }, function (req, res) {
         req.session.count = req.session.count || 0
         req.session.count++
         res.end('hits: ' + req.session.count)
@@ -2202,7 +2202,7 @@ describe('session()', function(){
 
     it('should touch on unmodified session', function (done) {
       var store = new ReqStore()
-      var server = createServer({ store: store, passReqToStore: true, resave: false }, function (req, res) {
+      var server = createServer({ store: store, resave: false }, function (req, res) {
         req.session.user = 'bob'
         res.end()
       })
@@ -2220,7 +2220,7 @@ describe('session()', function(){
 
     it('should respond correctly on destroy', function(done){
       var store = new ReqStore()
-      var server = createServer({ store: store, passReqToStore: true, unset: 'destroy' }, function (req, res) {
+      var server = createServer({ store: store, unset: 'destroy' }, function (req, res) {
         req.session.count = req.session.count || 0
         var count = ++req.session.count
         if (req.session.count > 1) {
@@ -2243,7 +2243,7 @@ describe('session()', function(){
 
     it('should persist', function(done){
       var store = new ReqStore()
-      var server = createServer({ store: store, passReqToStore: true }, function (req, res) {
+      var server = createServer({ store: store }, function (req, res) {
         req.session.count = req.session.count || 0
         req.session.count++
         res.end('hits: ' + req.session.count)

--- a/test/support/req-store.js
+++ b/test/support/req-store.js
@@ -12,6 +12,8 @@ function ReqStore () {
 
 util.inherits(ReqStore, session.Store)
 
+ReqStore.prototype.passReq = true
+
 ReqStore.prototype.destroy = function destroy (sid, req, callback) {
   delete this.sessions[req.hostname + ' ' + sid]
   callback()

--- a/test/support/req-store.js
+++ b/test/support/req-store.js
@@ -1,0 +1,29 @@
+'use strict'
+
+var session = require('../../')
+var util = require('util')
+
+module.exports = ReqStore
+
+function ReqStore () {
+  session.Store.call(this)
+  this.sessions = Object.create(null)
+}
+
+util.inherits(ReqStore, session.Store)
+
+ReqStore.prototype.destroy = function destroy (sid, req, callback) {
+  delete this.sessions[req.hostname + ' ' + sid]
+  callback()
+}
+
+ReqStore.prototype.get = function get (sid, req, callback) {
+  callback(null, JSON.parse(this.sessions[req.hostname + ' ' + sid]))
+}
+
+ReqStore.prototype.set = function set (sid, sess, req, callback) {
+  this.sessions[req.hostname + ' ' + sid] = JSON.stringify(sess)
+  callback()
+}
+
+ReqStore.prototype.touch = ReqStore.prototype.set


### PR DESCRIPTION
Enabled stores to receive the current request as a second to last argument, by detecting the available arguments the handling function expects.

See #711 for a use case.

This approach should even keep existing stores compatible.

This is similar in goal to #643, except that it lets the store handle the request, whereas that other PR would ask the application to swap out the store.