### PR TITLE
allow tolerance when checking cookie's maxAge

### DIFF
--- a/test/cookie.js
+++ b/test/cookie.js
@@ -91,7 +91,9 @@ describe('new Cookie()', function () {
         var maxAge = 60000
         var cookie = new Cookie({ maxAge: maxAge })
 
-        assert.strictEqual(cookie.maxAge, maxAge)
+        assert.strictEqual(typeof cookie.maxAge, 'number')
+        assert.ok(cookie.maxAge - 1000 <= maxAge)
+        assert.ok(cookie.maxAge + 1000 >= maxAge)
       })
 
       it('should accept Date object', function () {


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
- test/cookie.js fails intermittently `(59999 !== 60000)` when it checks the cookie's 'maxAge' against the value used when the cookie was created. Since this property is 'live', its current value (in ms) can occasionally decrease by the time the check is made. The test already deals with the (also live) 'expires' property in a similar way.