### PR TITLE
fix: reload calls exceeding stack track in case of errors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix internal method wrapping error on failed reloads
+
 1.17.0 / 2019-10-10
 ===================
 

--- a/index.js
+++ b/index.js
@@ -376,6 +376,16 @@ function session(options) {
       wrapmethods(req.session)
     }
 
+    function rewrapmethods (sess, callback) {
+      return function () {
+        if (req.session !== sess) {
+          wrapmethods(req.session)
+        }
+
+        callback.apply(this, arguments)
+      }
+    }
+
     // wrap session methods
     function wrapmethods(sess) {
       var _reload = sess.reload
@@ -383,10 +393,7 @@ function session(options) {
 
       function reload(callback) {
         debug('reloading %s', this.id)
-        _reload.call(this, function () {
-          wrapmethods(req.session)
-          callback.apply(this, arguments)
-        })
+        _reload.call(this, rewrapmethods(this, callback))
       }
 
       function save() {


### PR DESCRIPTION
When `reload`'s callback is called, it invokes `wrapmethods` on the
request session, ensuring the new session's `reload` call is overriden
with a custom `reload`, calling the original. However, there's no
guarantee a new session is created, resulting in `reload` overriding
an overriden `reload`! Given enough such override-overrides, the stack
will overflow, gruesomely erupting into several hundreds of lines of
callstack, leaving the lonely developer to wonder how he has reached
such a mess, reflecting on several important life choices.

Note that the testing framework, for reasons beyond my current
comprehension, did not correctly act upon this `RangeError`. When
running the new test case without the fix, the `mocha` call hangs
seemingly indefinitely. That may be deserving of further research, but
most deserving of a word of warning.