### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,7 @@ session data has been altered (though this behavior can be altered with various
 options in the middleware constructor). Because of this, typically this method
 does not need to be called.
 
-There are some cases where it is useful to call this method, for example,
-redirects, long-lived requests or in WebSockets.
+There are some cases where it is useful to call this method, for example, long-lived requests or in WebSockets.
 
 ```js
 req.session.save(function(err) {


### PR DESCRIPTION
Remove `redirects` from examples of when `session.save()` should be called.

Session is saved even after a redirect.