### PR TITLE
fix: unit test when sid not in store

### DIFF
--- a/test/session.js
+++ b/test/session.js
@@ -482,7 +482,7 @@ describe('session()', function(){
           .get('/')
           .set('Cookie', cookie(res))
           .expect(shouldSetCookie('connect.sid'))
-          .expect(shouldSetCookieToDifferentSessionId(res))
+          .expect(shouldSetCookieToDifferentSessionId(sid(res)))
           .expect(200, 'session 2', done)
         })
       })


### PR DESCRIPTION
Change the call to use sid function

```javascript
.expect(shouldSetCookieToDifferentSessionId(sid(res)))
```
