### PR TITLE
test: writeHead should merge

### DIFF
--- a/test/session.js
+++ b/test/session.js
@@ -1892,6 +1892,21 @@ describe('session()', function(){
           .expect(shouldSetCookieToValue('previous', 'cookieValue'))
           .expect(200, done)
         })
+
+        it('should preserve cookies set in writeHead', function (done) {
+          var server = createServer(null, function (req, res) {
+            var cookie = new Cookie()
+            res.writeHead(200, {
+              'Set-Cookie': cookie.serialize('previous', 'cookieValue')
+            })
+            res.end()
+          })
+
+          request(server)
+            .get('/')
+            .expect(shouldSetCookieToValue('previous', 'cookieValue'))
+            .expect(200, done)
+        })
       })
 
       describe('.originalMaxAge', function () {


### PR DESCRIPTION
The test checking that cookies should be preserved before writeHead is called should check in addition that when writeHead is called then the merge that is documented in the nodeJS docs does in fact get carried out in the manner we expect it to.

**writeHead** should merge on top of the existing value.