### PR TITLE
Update sha1 to sha256

### DIFF
--- a/index.js
+++ b/index.js
@@ -602,7 +602,7 @@ function hash(sess) {
 
   // hash
   return crypto
-    .createHash('sha1')
+    .createHash('sha256')
     .update(str, 'utf8')
     .digest('hex')
 }


### PR DESCRIPTION
Recent research shows that SHA1 is a weak hash function known to have collisions. Consider updating it to stronger collision resistant (at this time) hash functions like sha256.
Ref: 
https://shattered.io/
https://shattered.io/static/shattered.pdf
https://blog.qualys.com/ssllabs/2014/09/09/sha1-deprecation-what-you-need-to-know