### PR TITLE
Proxy res.end(callback) calls correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ function session(options) {
           return ret;
         }
 
-        if (chunk == null) {
+        if (chunk == null || typeof chunk === 'function') {
           ret = true;
           return ret;
         }

--- a/test/session.js
+++ b/test/session.js
@@ -189,6 +189,23 @@ describe('session()', function(){
     .expect(200, 'Hello, world!', done);
   })
 
+  it('should handle res.end(callback) calls', function (done) {
+    var callbackHasBeenCalled = false;
+
+    var server = createServer(null, function (req, res) {
+      function callback() {
+        callbackHasBeenCalled = true;
+      }
+
+      res.end(callback);
+    });
+
+    request(server).get('/').expect(200, '', function () {
+      assert.ok(callbackHasBeenCalled);
+      done();
+    })
+  });
+
   it('should handle res.end(null) calls', function (done) {
     var server = createServer(null, function (req, res) {
       res.end(null)


### PR DESCRIPTION
Hi! :wave:

This fixes #477. It bit me, and figuring out what broke in my application took forever, so I figured I'd try to fix it.

I'm not familiar with this code base at all, so please excuse any style breaches!

The test I added fails without the changes to `index.js`, and all the tests pass with the changes.

I will also attempt sending a PR updating the `express` docs on `res.end([data] [, encoding])` at https://expressjs.com/en/api.html#res, as they seem to suggest that `res.end` does not take a callback. It does!

Let me know if anything looks off!