### PR TITLE
docs: remove deprecated connect modules from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,11 +617,6 @@ and other multi-core embedded devices).
 [connect-mongodb-session-url]: https://www.npmjs.com/package/connect-mongodb-session
 [connect-mongodb-session-image]: https://badgen.net/github/stars/mongodb-js/connect-mongodb-session?label=%E2%98%85
 
-[![★][connect-mssql-image] connect-mssql][connect-mssql-url] A SQL Server-based session store.
-
-[connect-mssql-url]: https://www.npmjs.com/package/connect-mssql
-[connect-mssql-image]: https://badgen.net/github/stars/patriksimek/connect-mssql?label=%E2%98%85
-
 [![★][connect-pg-simple-image] connect-pg-simple][connect-pg-simple-url] A PostgreSQL-based session store.
 
 [connect-pg-simple-url]: https://www.npmjs.com/package/connect-pg-simple
@@ -663,11 +658,6 @@ and other multi-core embedded devices).
 
 [couchdb-expression-url]: https://www.npmjs.com/package/couchdb-expression
 [couchdb-expression-image]: https://badgen.net/github/stars/tkshnwesper/couchdb-expression?label=%E2%98%85
-
-[![★][documentdb-session-image] documentdb-session][documentdb-session-url] A session store for Microsoft Azure's [DocumentDB](https://azure.microsoft.com/en-us/services/documentdb/) NoSQL database service.
-
-[documentdb-session-url]: https://www.npmjs.com/package/documentdb-session
-[documentdb-session-image]: https://badgen.net/github/stars/dwhieb/documentdb-session?label=%E2%98%85
 
 [![★][dynamodb-store-image] dynamodb-store][dynamodb-store-url] A DynamoDB-based session store.
 


### PR DESCRIPTION
After going over the readme connect modules section in order to find which were being downloaded the most the following were found to be deprecated

- [connect-mssql](https://www.npmjs.com/package/connect-mssql) ~100 weekly downloads
- [documentdb-session](https://www.npmjs.com/package/documentdb-session) ~80 weekly downloads

both are now deprecated