### PR TITLE
Fix res.end patch to always commit headers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix `res.end` patch to always commit headers
   * deps: cookie@0.4.1
   * deps: safe-buffer@5.2.1
 

--- a/index.js
+++ b/index.js
@@ -272,6 +272,10 @@ function session(options) {
           return ret;
         }
 
+        if (!res._header) {
+          res._implicitHeader()
+        }
+
         if (chunk == null) {
           ret = true;
           return ret;


### PR DESCRIPTION
This adds a missing command to commit the progressive headers within `res.end` before attempting to read them. This has the standard side-effect of ensuring a second call to `res.end` will fail with a headers already set error. This is the same behavior other modules like `compression` does to get the headers set, same as the internal Node.js code of `res.end`.

Fixes #766