### PR TITLE
fix: secure='auto' and sameSite='none' case

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,6 +162,11 @@ function session(options) {
 
     if (cookieOptions.secure === 'auto') {
       req.session.cookie.secure = issecure(req, trustProxy);
+      // if sameSite is set to "none", secure is required,
+      // but auto can set secure to false, therefor remove sameSite attribute in this case
+      if (req.session.cookie.sameSite === 'none' && !req.session.cookie.secure) {
+        delete req.session.cookie.sameSite;
+      }
     }
   };
 


### PR DESCRIPTION
if secure is set to `auto` and sameSite is set to `none` it can result into secure is set to false, and therefore the cookie will not be set.
Because sameSite none always needs a secure context.

This fixes this behaviour, in case secure evaluates to false and sameSite is set explicitly to none, sameSite will be removed.

related to #778