### PR TITLE
Removes redundant check in session shouldTouch

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,7 +457,7 @@ function session(options) {
         return false;
       }
 
-      return cookieId === req.sessionID && !shouldSave(req);
+      return cookieId === req.sessionID;
     }
 
     // determine if cookie should be set on response


### PR DESCRIPTION
The shouldSave check is already performed in the caller (line 334) in an "either ... or ..." fashion.