### PR TITLE
Implement `checkTouchModified` option, improve hashing performance, upgrade eslint-plugin-markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,19 @@ will add an empty Passport object to the session for use after a user is
 authenticated, which will be treated as a modification to the session, causing
 it to be saved. *This has been fixed in PassportJS 0.3.0*
 
+##### checkTouchModified
+
+If set to `false`, unmodified sessions are always touched. However, when
+`rolling` is disabled, the expiration date in the cookie can differ from that
+which is in the store, since the cookie expiration date is only updated if the
+session is modified, but the session in the store is updated regardless.
+
+If set to `true` and the store supports "touching", unmodified sessions are not
+touched in the store at the end of each request. Manually calling
+`session.touch()` will extend the cookie expiry, and call `store.touch()`, which
+should implement server-side expiry extension.
+
+The default value is `false`.
 ##### secret
 
 **Required option**

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "after": "0.8.2",
     "cookie-parser": "1.4.5",
     "eslint": "7.26.0",
-    "eslint-plugin-markdown": "2.1.0",
+    "eslint-plugin-markdown": "2.2.0",
     "express": "4.17.1",
     "mocha": "8.4.0",
     "nyc": "15.1.0",


### PR DESCRIPTION
I've taken the idea from https://github.com/expressjs/session/pull/531 and done it in a way which I feel resolves the concerns from that thread.

Commit 1 modifies the hashing mechanism so that it doesn't get called multiple times per request, by caching the result. Commit 2 updates `eslint-plugin-markdown` to solve a security issue.

Commit 3 contains the new `checkTouchModified` option. If set to `true`, `session.touch()` does not get automatically called on every request. Instead, `shouldTouch` now checks if the session content or expiry has changed before calling `store.touch(...)`. This allows one to manually call `session.touch()` elsewhere in the application.