### PR TITLE
Corrected typographical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The default value is `undefined`.
 
 Forces the session to be saved back to the session store, even if the session
 was never modified during the request. Depending on your store this may be
-necessary, but it can also create race conditions where a client makes two
+necessary, but it can also create rare conditions where a client makes two
 parallel requests to your server and changes made to the session in one
 request may get overwritten when the other request ends, even if it made no
 changes (this behavior also depends on what store you're using).
@@ -257,7 +257,7 @@ Forces a session that is "uninitialized" to be saved to the store. A session is
 uninitialized when it is new but not modified. Choosing `false` is useful for
 implementing login sessions, reducing server storage usage, or complying with
 laws that require permission before setting a cookie. Choosing `false` will also
-help with race conditions where a client makes multiple parallel requests
+help with rare conditions where a client makes multiple parallel requests
 without a session.
 
 The default value is `true`, but using the default has been deprecated, as the


### PR DESCRIPTION
Corrected the typographical errors for the saveUninitialized documentation and the resave documentation in the README file.