### PR TITLE
test: make tests pass on Node.js >=16.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           node-version: "15.14"
 
         - name: Node.js 16.x
-          node-version: "16.2"
+          node-version: "16.9"
 
     steps:
     - uses: actions/checkout@v2

--- a/test/session.js
+++ b/test/session.js
@@ -581,7 +581,7 @@ describe('session()', function(){
           request(server)
           .get('/')
           .set('Cookie', cookie(res))
-          .expect(500, /Cannot read property/, done)
+          .expect(500, /Cannot read prop/, done)
         })
       })
     })


### PR DESCRIPTION
With V8 9.3, the error message is: "Cannot read properties of undefined (reading 'expires')"

See https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/2754/nodes=fedora-latest-x64/testReport/junit/(root)/citgm/express_session_v1_17_2/