### PR TITLE
fix: skip re-saving session when not modified since save

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix resaving already-saved new session at end of request
   * deps: cookie@0.4.2
 
 1.17.2 / 2021-05-19

--- a/index.js
+++ b/index.js
@@ -444,7 +444,7 @@ function session(options) {
         return false;
       }
 
-      return !saveUninitializedSession && cookieId !== req.sessionID
+      return !saveUninitializedSession && !savedHash && cookieId !== req.sessionID
         ? isModified(req.session)
         : !isSaved(req.session)
     }

--- a/test/session.js
+++ b/test/session.js
@@ -1775,6 +1775,31 @@ describe('session()', function(){
           .expect(200, 'saved', done)
         })
       })
+
+      describe('when saveUninitialized is false', function () {
+        it('should prevent end-of-request save', function (done) {
+          var store = new session.MemoryStore()
+          var server = createServer({ saveUninitialized: false, store: store }, function (req, res) {
+            req.session.hit = true
+            req.session.save(function (err) {
+              if (err) return res.end(err.message)
+              res.end('saved')
+            })
+          })
+
+          request(server)
+            .get('/')
+            .expect(shouldSetSessionInStore(store))
+            .expect(200, 'saved', function (err, res) {
+              if (err) return done(err)
+              request(server)
+                .get('/')
+                .set('Cookie', cookie(res))
+                .expect(shouldSetSessionInStore(store))
+                .expect(200, 'saved', done)
+            })
+        })
+      })
     })
 
     describe('.touch()', function () {


### PR DESCRIPTION
When the `saveUninitialized` option is set to false, sessions will be
saved at the end of the request even when they have already been saved
earlier in the request and not subsequently modified. The result is a
double save that can potentially be wasteful with the persistence layer.
This change checks for modification of the session before saving, and
saves only if needed.