### PR TITLE
fix: skip re-saving session when not modified since save

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,6 +444,10 @@ function session(options) {
         return false;
       }
 
+      if (savedHash) {
+        return !isSaved(req.session);
+      }
+
       return !saveUninitializedSession && cookieId !== req.sessionID
         ? isModified(req.session)
         : !isSaved(req.session)

--- a/test/session.js
+++ b/test/session.js
@@ -1775,6 +1775,29 @@ describe('session()', function(){
           .expect(200, 'saved', done)
         })
       })
+
+      it('should prevent end-of-request save when saveUninitialized option is set to false', function (done) {
+        var store = new session.MemoryStore()
+        var server = createServer({ store: store, saveUninitialized: false }, function (req, res) {
+          req.session.hit = true
+          req.session.save(function (err) {
+            if (err) return res.end(err.message)
+            res.end('saved')
+          })
+        })
+
+        request(server)
+        .get('/')
+        .expect(shouldSetSessionInStore(store))
+        .expect(200, 'saved', function (err, res) {
+          if (err) return done(err)
+          request(server)
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(shouldSetSessionInStore(store))
+          .expect(200, 'saved', done)
+        })
+      })
     })
 
     describe('.touch()', function () {


### PR DESCRIPTION
When the `saveUninitialized` option is set to false, sessions will be
saved at the end of the request even when they have already been saved
earlier in the request and not subsequently modified. The result is a
double save that can potentially be wasteful with the persistence layer.
This change checks for modification of the session before saving, and
saves only if needed.