### PR TITLE
Add secure cookies when remote is localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ the cookie back to the server in the future if the browser does not have an HTTP
 connection.
 
 Please note that `secure: true` is a **recommended** option. However, it requires
-an https-enabled website, i.e., HTTPS is necessary for secure cookies. If `secure`
-is set, and you access your site over HTTP, the cookie will not be set. If you
-have your node.js behind a proxy and are using `secure: true`, you need to set
-"trust proxy" in express:
+an https-enabled website (or connection via localhost), i.e., HTTPS is necessary
+for secure cookies. If `secure` is set, and you access your site over HTTP, the 
+cookie will not be set. If you have your node.js behind a proxy and are using
+`secure: true`, you need to set "trust proxy" in express:
 
 ```js
 var app = express()

--- a/index.js
+++ b/index.js
@@ -621,6 +621,14 @@ function hash(sess) {
  */
 
 function issecure(req, trustProxy) {
+
+  // socket is localhost
+  if (req.connection.remoteAddress === '127.0.0.1' ||
+      req.connection.remoteAddress === '::ffff:127.0.0.1'
+  ) {
+    return true;
+  }
+
   // socket is https server
   if (req.connection && req.connection.encrypted) {
     return true;

--- a/test/session.js
+++ b/test/session.js
@@ -610,6 +610,7 @@ describe('session()', function(){
         .expect(200, done)
       })
 
+      // TODO: Fix tests
       it('should work when no header', function(done){
         request(server)
         .get('/')


### PR DESCRIPTION
See #857

This PR enables secure cookies to be transmitted when the remoteAddress is localhost (both IPv4 & IPv6)

I also updated the README to match the new behavior, but I need help writing the tests: the one marked 'TODO' currently fails, we would need to create a couple of tests for both localhost connection and non-localhost one.