### PR TITLE
build: Upper-case `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,5 +176,5 @@ jobs:
     - name: Upload code coverage
       uses: coverallsapp/github-action@master
       with:
-        github-token: ${{ secrets.github_token }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true


### PR DESCRIPTION
[The documentation][1] says, "Secret names are not case-sensitive." However, using upper-case letters improves readability by avoiding questions about whether lower-case is acceptable. It also matches the capitalization used earlier in the file (line 168) and in documentation.

[1]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#naming-your-secrets
