### PR TITLE
Cookie: Fix originalMaxAge option corruption

### DIFF
--- a/session/cookie.js
+++ b/session/cookie.js
@@ -32,7 +32,26 @@ var Cookie = module.exports = function Cookie(options) {
       throw new TypeError('argument options must be a object')
     }
 
+    var keys = [];
     for (var key in options) {
+      keys.push(key);
+    }
+    keys.sort(function(a, b) {
+      var relativeOrder = {
+        // The setter for .maxAge modifies .expires, so .maxAge must be set before .expires if both
+        // are present in options.
+        maxAge: 0,
+        // The setter for .expires modifies ._expires and .originalMaxAge, so it must be set before
+        // those.
+        expires: 1,
+        _expires: 2,
+        originalMaxAge: 2,
+      };
+      if (!(a in relativeOrder) || !(b in relativeOrder)) return 0;
+      return relativeOrder[a] - relativeOrder[b];
+    });
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
       if (key !== 'data') {
         this[key] = options[key]
       }

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -56,6 +56,19 @@ describe('new Cookie()', function () {
         assert.strictEqual(cookie.expires, expires)
       })
 
+      it('should not override originalMaxAge option', function () {
+        // This test relies on for-in iteration order, but for-in iteration order is only specified
+        // in ES2020 and later (https://stackoverflow.com/a/30919039). Thus, this test might not be
+        // reliable on older versions of Node.js (it might pass when it should fail, but it will
+        // never fail when it should pass).
+        var cookie = new Cookie({ originalMaxAge: 1000, expires: new Date(1) })
+        assert.strictEqual(cookie.originalMaxAge, 1000);
+        // Repeat the test but with the property definition order swapped in case that causes for-in
+        // iteration order to also swap on older Node.js releases.
+        cookie = new Cookie({ expires: new Date(1), originalMaxAge: 1000 })
+        assert.strictEqual(cookie.originalMaxAge, 1000);
+      })
+
       it('should set maxAge', function () {
         var expires = new Date(Date.now() + 60000)
         var cookie = new Cookie({ expires: expires })


### PR DESCRIPTION
This is necessary to survive a round trip to JSON. (But it is not sufficient—the `expires` option must be converted from a string to a `Date` object. This will be addressed in a future pull request.)