### PR TITLE
Removing unnecessary files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "files": [
     "session/",
     "HISTORY.md",
-    "LICENSE",
     "index.js"
   ],
   "engines": {


### PR DESCRIPTION
To state the npm documentation:

```
Certain files are always included, regardless of settings:

    package.json
    README
    CHANGES / CHANGELOG / HISTORY
    LICENSE / LICENCE
    NOTICE
    The file in the "main" field

README, CHANGES, LICENSE & NOTICE can have any case and extension.
```