### PR TITLE
Compat stores: Add connect-lowdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,11 @@ and other multi-core embedded devices).
 [connect-loki-url]: https://www.npmjs.com/package/connect-loki
 [connect-loki-image]: https://badgen.net/github/stars/Requarks/connect-loki?label=%E2%98%85
 
+[![★][connect-lowdb-image] connect-lowdb][connect-lowdb-url] A lowdb-based session store.
+
+[connect-lowdb-url]: https://www.npmjs.com/package/connect-lowdb
+[connect-lowdb-image]: https://badgen.net/github/stars/travishorn/connect-lowdb?label=%E2%98%85
+
 [![★][connect-memcached-image] connect-memcached][connect-memcached-url] A memcached-based session store.
 
 [connect-memcached-url]: https://www.npmjs.com/package/connect-memcached


### PR DESCRIPTION
Added [connect-lowdb](https://github.com/travishorn/connect-lowdb) to list of compatible session stores.

There is a similar [lowdb-session-store](https://www.npmjs.com/package/lowdb-session-store) but that one apparently hasn't worked since lowdb 2.0.0 (May 2021).