### PR TITLE
Support "Forwarded" header too

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,12 @@ each other. The simplest method is to simply set different `name`s per app.
 
 ##### proxy
 
-Trust the reverse proxy when setting secure cookies (via the "X-Forwarded-Proto"
+Trust the reverse proxy when setting secure cookies (via the "X-Forwarded-Proto" or "Forwarded"
 header).
 
 The default value is `undefined`.
 
-  - `true` The "X-Forwarded-Proto" header will be used.
+  - `true` The "X-Forwarded-Proto" or "Forwarded" header will be used.
   - `false` All headers are ignored and the connection is considered secure only
     if there is a direct TLS/SSL connection.
   - `undefined` Uses the "trust proxy" setting from express

--- a/index.js
+++ b/index.js
@@ -643,7 +643,16 @@ function issecure(req, trustProxy) {
     ? header.substr(0, index).toLowerCase().trim()
     : header.toLowerCase().trim()
 
-  return proto === 'https';
+  if (proto === 'https') {
+    return true;
+  }
+  
+  // read proto from the standardized replacement 'Forwarded' header
+  if (req.headers['forwarded']) {
+    return req.headers['forwarded'].indexOf('proto=https') !== -1;
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
Since there is a standardized replacement for `X-Forwarded-Proto`, the new [`Forwarded` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), we should probably support this too.

This change adds a check for the new header, after all preexisting checks for `issecure`. This allows to set secure cookies when a `Forwarded: proto=https` header is present.