### PR TITLE
Adding verification that sess.cookie is set

### DIFF
--- a/session/store.js
+++ b/session/store.js
@@ -68,7 +68,7 @@ Store.prototype.load = function(sid, fn){
   var self = this;
   this.get(sid, function(err, sess){
     if (err) return fn(err);
-    if (!sess) return fn();
+    if (!sess || !sess.cookie) return fn();
     var req = { sessionID: sid, sessionStore: self };
     fn(null, self.createSession(req, sess))
   });


### PR DESCRIPTION
In the environment where I'm using `express-session`, sometimes the session is set to `{}`. That causes this library to crash, because upon session load/creation it is currently only checking if `sess` is truthy, and is not checking that `sess.cookie` exists, prior to accessing properties on `sess.cookie`. 

The library currently throws the error `Cannot read property 'expires' of undefined`, and I have not found an elegant way to catch that error. This change should resolve the issue, by no longer calling `self.createSession` in the event that `sess.cookie` is unset.