### PR TITLE
Pass new session as extra param to Session reload and regenerate callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ a new SID and `Session` instance will be initialized at `req.session`
 and the `callback` will be invoked.
 
 ```js
-req.session.regenerate(function(err) {
+req.session.regenerate(function(err, session) {
   // will have a new session here
 })
 ```
@@ -363,7 +363,7 @@ Reloads the session data from the store and re-populates the
 `req.session` object. Once complete, the `callback` will be invoked.
 
 ```js
-req.session.reload(function(err) {
+req.session.reload(function(err, session) {
   // session updated
 })
 ```

--- a/session/session.js
+++ b/session/session.js
@@ -75,10 +75,10 @@ defineMethod(Session.prototype, 'save', function save(fn) {
 
 /**
  * Re-loads the session data _without_ altering
- * the maxAge properties. Invokes the callback `fn(err)`,
+ * the maxAge properties. Invokes the callback `fn(err, session)`,
  * after which time if no exception has occurred the
- * `req.session` property will be a new `Session` object,
- * although representing the same session.
+ * `req.session` property and `session` callback param will be
+ * the new `Session` object, although representing the same session.
  *
  * @param {Function} fn
  * @return {Session} for chaining
@@ -93,7 +93,7 @@ defineMethod(Session.prototype, 'reload', function reload(fn) {
     if (err) return fn(err);
     if (!sess) return fn(new Error('failed to load session'));
     store.createSession(req, sess);
-    fn();
+    fn(null, req.session);
   });
   return this;
 });
@@ -113,7 +113,8 @@ defineMethod(Session.prototype, 'destroy', function destroy(fn) {
 });
 
 /**
- * Regenerate this request's session.
+ * Regenerate this request's session. Invokes the callback `fn(err, session)`
+ * with the new session object or an error if one occurred.
  *
  * @param {Function} fn
  * @return {Session} for chaining
@@ -140,4 +141,4 @@ function defineMethod(obj, name, fn) {
     value: fn,
     writable: true
   });
-};
+}

--- a/session/store.js
+++ b/session/store.js
@@ -51,7 +51,7 @@ Store.prototype.regenerate = function(req, fn){
   var self = this;
   this.destroy(req.sessionID, function(err){
     self.generate(req);
-    fn(err);
+    fn(err, req.session);
   });
 };
 


### PR DESCRIPTION
Why? The scope calling regenerate (or reload) does not necessarily want or need to know what a `req` is. Passing the new session object as a callback parameter allows the callback to regenerate or resave then make changes without knowing about `req`. Example:

```
  session.regenerate((err, newSession) => {
    if(err) return next(err);
    session.justRegenerated = true;  // Just an example.
  });
```

I specifically wanted this to `Session.regenerate` but added to `Session.reload` too for consistency. Might also want it in `Session.save` callback but that seems to require change in the behaviour of plugins so I gave it a pass.