### PR TITLE
refactor: replaced _implicitHeader

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ function session(options) {
           return ret;
         }
 
-        if (!res._header) {
+        if (typeof res.headersSent === 'boolean' ? !res.headersSent : !res._header) {
           res.writeHead(res.statusCode)
         }
 

--- a/index.js
+++ b/index.js
@@ -273,7 +273,7 @@ function session(options) {
         }
 
         if (!res._header) {
-          res._implicitHeader()
+          res.writeHead(res.statusCode)
         }
 
         if (chunk == null) {

--- a/test/session.js
+++ b/test/session.js
@@ -1381,6 +1381,25 @@ describe('session()', function(){
     })
   });
 
+  describe('res._header patch', function () {
+    it('should be equivalent to res.headersSent', function (done) {
+      request(createServer(function(req, res) {
+        assert.strictEqual(!!res._header, !!res.headersSent,
+          'res._header should be equal to res.headersSent (prior state change)')
+
+        var oldState = !!res._header;
+        res.end('ended')
+        var newState = !!res._header;
+        assert.notStrictEqual(oldState, newState)
+
+        assert.strictEqual(!!res._header, !!res.headersSent,
+          'res._header should be equal to res.headersSent (after state change)')
+      }))
+      .get('/')
+      .expect(200, 'ended', done)
+    })
+  })
+
   describe('res.end patch', function () {
     it('should correctly handle res.end/res.write patched prior', function (done) {
       function setup (req, res) {

--- a/test/session.js
+++ b/test/session.js
@@ -2313,10 +2313,7 @@ describe('session()', function(){
       })
       server.on('listening', function () {
         var client = createHttp2Client(server.address().port)
-        // using ES5 as Node.js <=4.0.0 does not have Computed Property Names
-        var reqHeaders = {}
-        reqHeaders[http2.constants.HTTP2_HEADER_PATH] = '/'
-        var request = client.request(reqHeaders)
+        var request = client.request()
         request.on('response', function (headers) {
           assert.strictEqual(headers[http2.constants.HTTP2_HEADER_STATUS], 200)
           assert.strictEqual(headers[http2.constants.HTTP2_HEADER_CONTENT_TYPE], 'text/plain')


### PR DESCRIPTION
Fixes #888

Replaced the usage of undocumented HTTP API with its implementation instead (bringing about **_some_*** http2 support).
There is no change to the existing behavior. This is similar to https://github.com/expressjs/compression/pull/170.

- Undocumented `res._implicitHeader` https://github.com/nodejs/node/blob/a8bc202d855cc7d14895db38a2ac09d1f873e803/lib/_http_server.js#L281
Replaced with `res._implicitHeader` implementation
https://github.com/nodejs/node/blob/a8bc202d855cc7d14895db38a2ac09d1f873e803/lib/_http_server.js#L282


- Undocumented `res._header` 
https://github.com/nodejs/node/blob/93e0bf9abf350637d772bcce14a5d9527b733300/lib/_http_outgoing.js#L741
Replaced with `res.headersSent`
https://github.com/nodejs/node/blob/93e0bf9abf350637d772bcce14a5d9527b733300/lib/_http_outgoing.js#L745

The changes do not require a semver major. 

_**some**_* - This change may/may not provide full http2 support. 

