### PR TITLE
add sequelize-mariadb-store-to-README

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,9 +829,10 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 [tch-nedb-session-url]: https://www.npmjs.com/package/tch-nedb-session
 [tch-nedb-session-image]: https://badgen.net/github/stars/tomaschyly/NeDBSession?label=%E2%98%85
 
-[sequelize-mariadb-store][sequelize-mariadb-store-url] Store based in sequelize and MariaDB
+[![★][sequelize-mariadb-store-image] sequelize-mariadb-store][sequelize-mariadb-store-url] Store based in sequelize and MariaDB
 
 [sequelize-mariadb-store-url]: https://www.npmjs.com/package/@duskim/express-store
+[sequelize-mariadb-store-image]: https://badgen.net/github/stars/duskim/sequelize-mariadb-store?label=%E2%98%85
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -738,6 +738,11 @@ a [variety of storage types](https://www.npmjs.com/package/cache-manager#store-e
 [express-sessions-url]: https://www.npmjs.com/package/express-sessions
 [express-sessions-image]: https://badgen.net/github/stars/konteck/express-sessions?label=%E2%98%85
 
+[![★][@duskim/express-store-image] @duskim/express-store][@duskim/express-store-url] Store based in sequelize and MariaDB.
+
+[@duskim/express-store-url]: https://www.npmjs.com/package/@duskim/express-store
+[@duskim/express-store-image]: https://badgen.net/github/stars/duskim/express-store?label=%E2%98%85
+
 [![★][firestore-store-image] firestore-store][firestore-store-url] A [Firestore](https://github.com/hendrysadrak/firestore-store)-based session store.
 
 [firestore-store-url]: https://www.npmjs.com/package/firestore-store
@@ -793,11 +798,6 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 
 [restsession-url]: https://www.npmjs.com/package/restsession
 [restsession-image]: https://badgen.net/github/stars/jankal/restsession?label=%E2%98%85
-
-[![★][sequelize-mariadb-store-image] sequelize-mariadb-store][sequelize-mariadb-store-url] Store based in sequelize and MariaDB
-
-[sequelize-mariadb-store-url]: https://www.npmjs.com/package/@duskim/express-store
-[sequelize-mariadb-store-image]: https://badgen.net/github/stars/duskim/sequelize-mariadb-store?label=%E2%98%85
 
 [![★][sequelstore-connect-image] sequelstore-connect][sequelstore-connect-url] A session store using [Sequelize.js](http://sequelizejs.com/).
 

--- a/README.md
+++ b/README.md
@@ -833,7 +833,6 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 
 [sequelize-mariadb-store-url]: https://www.npmjs.com/package/@duskim/express-store
 
-
 ## Examples
 
 ### View counter

--- a/README.md
+++ b/README.md
@@ -794,6 +794,11 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 [restsession-url]: https://www.npmjs.com/package/restsession
 [restsession-image]: https://badgen.net/github/stars/jankal/restsession?label=%E2%98%85
 
+[![★][sequelize-mariadb-store-image] sequelize-mariadb-store][sequelize-mariadb-store-url] Store based in sequelize and MariaDB
+
+[sequelize-mariadb-store-url]: https://www.npmjs.com/package/@duskim/express-store
+[sequelize-mariadb-store-image]: https://badgen.net/github/stars/duskim/sequelize-mariadb-store?label=%E2%98%85
+
 [![★][sequelstore-connect-image] sequelstore-connect][sequelstore-connect-url] A session store using [Sequelize.js](http://sequelizejs.com/).
 
 [sequelstore-connect-url]: https://www.npmjs.com/package/sequelstore-connect
@@ -828,11 +833,6 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 
 [tch-nedb-session-url]: https://www.npmjs.com/package/tch-nedb-session
 [tch-nedb-session-image]: https://badgen.net/github/stars/tomaschyly/NeDBSession?label=%E2%98%85
-
-[![★][sequelize-mariadb-store-image] sequelize-mariadb-store][sequelize-mariadb-store-url] Store based in sequelize and MariaDB
-
-[sequelize-mariadb-store-url]: https://www.npmjs.com/package/@duskim/express-store
-[sequelize-mariadb-store-image]: https://badgen.net/github/stars/duskim/sequelize-mariadb-store?label=%E2%98%85
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -829,6 +829,11 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 [tch-nedb-session-url]: https://www.npmjs.com/package/tch-nedb-session
 [tch-nedb-session-image]: https://badgen.net/github/stars/tomaschyly/NeDBSession?label=%E2%98%85
 
+[sequelize-mariadb-store][sequelize-mariadb-store-url] Store based in sequelize and MariaDB
+
+[sequelize-mariadb-store-url]: https://www.npmjs.com/package/@duskim/express-store
+
+
 ## Examples
 
 ### View counter


### PR DESCRIPTION
Implementation of Express Session store written in Sequelize, works with MariaDB. Touch is implemented to update expires. Pass in ttc to change interval of clearing sessions to options (in milliseconds).

https://github.com/duskim/sequelize-mariadb-store
https://www.npmjs.com/package/@duskim/express-store?activeTab=readme
