### PR TITLE
Add cookie.priority

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,12 @@
 unreleased
 ==========
 
+  * Add `priority` to `cookie` options
   * Support any type in `secret` that `crypto.createHmac` supports
+  * deps: cookie@0.5.0
+    - Fix `expires` option to reject invalid dates
+    - perf: improve default decode speed
+    - perf: remove slow string split in parse
   * deps: cookie-signature@1.0.7
 
 1.17.3 / 2022-05-11

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ defined in the object is what is used.
 Specifies the value for the `Path` `Set-Cookie`. By default, this is set to `'/'`, which
 is the root path of the domain.
 
+##### cookie.priority
+
+Specifies the `string` to be the value for the [`Priority` `Set-Cookie` attribute][rfc-west-cookie-priority-00-4.1].
+
+  - `'low'` will set the `Priority` attribute to `Low`.
+  - `'medium'` will set the `Priority` attribute to `Medium`, the default priority when not set.
+  - `'high'` will set the `Priority` attribute to `High`.
+
+More information about the different priority levels can be found in
+[the specification][rfc-west-cookie-priority-00-4.1].
+
+**Note** This is an attribute that has not yet been fully standardized, and may change in the future.
+This also means many clients may ignore this attribute until they understand it.
+
 ##### cookie.sameSite
 
 Specifies the `boolean` or `string` to be the value for the `SameSite` `Set-Cookie` attribute.
@@ -994,6 +1008,7 @@ On Windows, use the corresponding command;
 [MIT](LICENSE)
 
 [rfc-6265bis-03-4.1.2.7]: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7
+[rfc-west-cookie-priority-00-4.1]: https://tools.ietf.org/html/draft-west-cookie-priority-00#section-4.1
 [ci-image]: https://badgen.net/github/checks/expressjs/session/master?label=ci
 [ci-url]: https://github.com/expressjs/session/actions?query=workflow%3Aci
 [coveralls-image]: https://badgen.net/coveralls/c/github/expressjs/session/master

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "expressjs/session",
   "license": "MIT",
   "dependencies": {
-    "cookie": "0.4.2",
+    "cookie": "0.5.0",
     "cookie-signature": "1.0.7",
     "debug": "2.6.9",
     "depd": "~2.0.0",

--- a/session/cookie.js
+++ b/session/cookie.js
@@ -116,7 +116,8 @@ Cookie.prototype = {
 
   get data() {
     return {
-      originalMaxAge: this.originalMaxAge
+      originalMaxAge: this.originalMaxAge,
+      priority: this.priority
       , expires: this._expires
       , secure: this.secure
       , httpOnly: this.httpOnly

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -114,5 +114,13 @@ describe('new Cookie()', function () {
         assert.strictEqual(cookie.path, '/foo')
       })
     })
+
+    describe('priority', function () {
+      it('should set priority', function () {
+        var cookie = new Cookie({ priority: 'high' })
+
+        assert.strictEqual(cookie.priority, 'high')
+      })
+    })
   })
 })

--- a/test/session.js
+++ b/test/session.js
@@ -1923,18 +1923,26 @@ describe('session()', function(){
         })
 
         it('should override defaults', function(done){
-          var server = createServer({ cookie: { path: '/admin', httpOnly: false, secure: true, maxAge: 5000 } }, function (req, res) {
+          var opts = {
+            httpOnly: false,
+            maxAge: 5000,
+            path: '/admin',
+            priority: 'high',
+            secure: true
+          }
+          var server = createServer({ cookie: opts }, function (req, res) {
             req.session.cookie.secure = false
             res.end()
           })
 
           request(server)
-          .get('/admin')
-          .expect(shouldSetCookieWithAttribute('connect.sid', 'Expires'))
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'HttpOnly'))
-          .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'Path', '/admin'))
-          .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
-          .expect(200, done)
+            .get('/admin')
+            .expect(shouldSetCookieWithAttribute('connect.sid', 'Expires'))
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'HttpOnly'))
+            .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'Path', '/admin'))
+            .expect(shouldSetCookieWithoutAttribute('connect.sid', 'Secure'))
+            .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'Priority', 'High'))
+            .expect(200, done)
         })
 
         it('should preserve cookies set before writeHead is called', function(done){


### PR DESCRIPTION
This adds cookie.priority by passing this property through to cookie (which requires us to upgrade cookie to >=0.5.0).

The priority option is not fully standardized, but has been proposed and in-use since 2016.

See also: https://github.com/jshttp/cookie/issues/138
Fixes: #884