### PR TITLE
Remove warning about SameSite cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,6 @@ By default, this is `false`.
 More information about the different enforcement levels can be found in
 [the specification][rfc-6265bis-03-4.1.2.7].
 
-**Note** This is an attribute that has not yet been fully standardized, and may change in
-the future. This also means many clients may ignore this attribute until they understand it.
-
 **Note** There is a [draft spec](https://tools.ietf.org/html/draft-west-cookie-incrementalism-01)
 that requires that the `Secure` attribute be set to `true` when the `SameSite` attribute has been
 set to `'none'`. Some web browsers or other clients may be adopting this specification.


### PR DESCRIPTION
@dougwilson: express-session's warning about the SameSite cookie was [written 7 years ago](https://github.com/expressjs/session/commit/40afdb04b) and the landscape has changed since then. It's true that the attribute still isn't fully standardized, but it [has settled](https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/) and [all modern browsers](https://caniuse.com/?search=samesite) have supported the SameSite attribute for a few years now (even IE11 has partial support).

Browsers do differ in behavior when SameSite is _not_ set (Chrome treats this as "Lax", Firefox doesn't yet but emits a console warning that it will "soon"; neither Safari nor IE11 do this). Setting the attribute now yields more consistent results across browsers than not setting it.