### PR TITLE
README: remove rethinkDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,11 +837,6 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 [session-pouchdb-store-url]: https://www.npmjs.com/package/session-pouchdb-store
 [session-pouchdb-store-image]: https://badgen.net/github/stars/solzimer/session-pouchdb-store?label=%E2%98%85
 
-[![★][session-rethinkdb-image] session-rethinkdb][session-rethinkdb-url] A [RethinkDB](http://rethinkdb.com/)-based session store.
-
-[session-rethinkdb-url]: https://www.npmjs.com/package/session-rethinkdb
-[session-rethinkdb-image]: https://badgen.net/github/stars/llambda/session-rethinkdb?label=%E2%98%85
-
 [![★][@cyclic.sh/session-store-image] @cyclic.sh/session-store][@cyclic.sh/session-store-url] A DynamoDB-based session store for [Cyclic.sh](https://www.cyclic.sh/) apps.
 
 [@cyclic.sh/session-store-url]: https://www.npmjs.com/package/@cyclic.sh/session-store


### PR DESCRIPTION
This npmjs package is dead for mysterious reasons.

https://www.npmjs.com/package/session-rethinkdb

![image](https://github.com/expressjs/session/assets/16578570/555c69da-cae6-46c0-9d38-37be04c1118e)

Outside the fact is was abandoned for 6 years, it's no longer indexed on npmjs, you can access it only with the direct link.

The upstream repository disappeared too: https://github.com/llambda/session-rethinkdb.

There seems to be alternatives:

- https://www.npmjs.com/package/session-rethinkdb-ts
- https://www.npmjs.com/package/express-session-rethinkdb-esm

