### PR TITLE
Add support for plain asterisk route

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ function session(options) {
 
     // pathname mismatch
     var originalPath = parseUrl.original(req).pathname || '/'
-    if (originalPath.indexOf(cookieOptions.path || '/') !== 0) {
+    if (originalPath.indexOf(cookieOptions.path || '/') !== 0 && originalPath !== '*') {
       debug('pathname mismatch')
       next()
       return


### PR DESCRIPTION
When an `OPTIONS` request with a plain asterisk (*) as the URL is made to the server, the session object is not getting attached to the `req` object.

To replicate the issue:

JS code:
```
app.use(sessionMiddleware);
app.use(function(req, res, next) {
  if (req.session.uid) return next();
  res.sendStatus(401);
});
```

Client command:
`curl -X OPTIONS --request-target "*" example.com -i`

Expected: `req.session` not being `undefined` regardless of the request
Actual: `req.session` is `undefined`