### PR TITLE
Allow `OPTIONS *` requests to pass cookie path check for default setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,15 +76,14 @@ var defer = typeof setImmediate === 'function'
  * for all paths in OPTIONS requests.
  *
  * @param {string} originalPath - The original request path.
- * @param {Object} cookieOptions - The cookie options object.
- * @param {string} cookieOptions.path - The path for which the cookie is set.
+ * @param {string} cookiePath - The path for which the cookie is set.
  * @returns {boolean} Returns true if the original path matches the cookie path, false otherwise.
  */
-function verifyPath(originalPath, cookieOptions) {
+function verifyPath(originalPath, cookiePath) {
   if (originalPath === '*') {
-    return cookieOptions.path === '/';
+    return cookiePath === '/';
   }
-  return originalPath.indexOf(cookieOptions.path || '/') === 0;
+  return originalPath.indexOf(cookiePath || '/') === 0;
 }
 
 /**
@@ -213,7 +212,7 @@ function session(options) {
     }
     // pathname mismatch
     var originalPath = parseUrl.original(req).pathname || '/'
-    if (!verifyPath(originalPath, cookieOptions)) {
+    if (!verifyPath(originalPath, cookieOptions.path)) {
       debug('pathname mismatch')
       next()
       return


### PR DESCRIPTION
Based on the discussion in #976 

tldr; we add sessions to OPTIONS already, as long as the path matches the cookie settings, except for the rare but valid `OPTIONS *` request

https://github.com/expressjs/session/pull/976#issuecomment-1980036795

> Actually this isn't a spec issue. The spec informs that this is a valid request, and Node lets it through because of that. But whether the request matches the path we've configured is up for debate. We're comparing the path option for cookies to the request's path. 
> 
> The semantics of cookie path matching and wildcard requests don't map well to each other. Given a specific path like: `cookieOptions.path = "/api/v1/"` we are checking that we allow everything under it's subdirs such as `/api/v1/foo || /api/v1/foo/bar/baz`, while blocking `/api/v2/foo`. So I'd consider `cookieOptions.path = /api/v1/` to not match `*` because our cookie is set granularly.
> 
> But the default is `cookieOptions.path = "/"` which covers all subdirs on the domain. I'd consider that equivalent to `*` and would expect the options wildcard request to pass under the default.
> 
> I don't think anyone else handles this, [fastify session](https://github.com/fastify/session/blob/7587d08c33c11f8e0fe603ce4b27d5ee88329487/lib/fastifySession.js#L134) would also not match the path for example. 
> 
> So if a change was going to be taken, it should be to treat a wildcard as semantically the same as when the cookie path is set to all subdirs. Because apparently HTTP has more than one way to express "all subdirs" by way of the options wildcard request-target. TIL
> 
> (note: should anyone bother with sessions on OPTIONS? also up for debate! but the reality is rn we would dress all options requests in sessions with the default settings, except these wildcard ones)