### PR TITLE
Potential solution for Cookie options(secure) in Local HTTP Environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ function session(options) {
       }
 
       // only send secure cookies via https
-      if (req.session.cookie.secure && !issecure(req, trustProxy)) {
+      if (req.session.cookie.secure && !issecure(req, trustProxy) && !isRunningLocally()) {
         debug('not secured');
         return;
       }
@@ -652,6 +652,23 @@ function issecure(req, trustProxy) {
     : header.toLowerCase().trim()
 
   return proto === 'https';
+}
+
+/**
+ * Determine if application is running locally.
+ *
+ * @return {Boolean}
+ * @private
+ */
+
+function isRunningLocally() {
+  if (os.hostname() === 'localhost') {
+    return true;
+  }
+  var interfaces = os.networkInterfaces();
+  return Object.values(interfaces).flat().some(iface =>
+    iface.address === '127.0.0.1' || iface.address === '::1'
+  );
 }
 
 /**


### PR DESCRIPTION
From my understanding, if we are running our application locally without using HTTPS and Nginx or something similar, secure will not work under the logic of express-session.

In the latest version of Chrome and Firefox HTTPS requirements are ignored when the Secure attribute is set by localhost, please see the MDN documents below:
[https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie](url)
![image](https://github.com/expressjs/session/assets/94886510/9c123376-4909-4e07-9b41-4f919b1cb768)
Chrome permits setting the secure attribute for cookies under HTTP on localhost. However, express-session does not create cookies under HTTP, which is why cookies might not appear even if the secure and sameSite are correctly set.

I wonder if we can refine logic to align with Chrome rules, so I tried to do some 'naive' optimization by checking if application is running locally.
<img width="621" alt="image" src="https://github.com/expressjs/session/assets/94886510/fd77d6c3-ba31-4a10-8d7d-94255b7ecb47">
<img width="448" alt="image" src="https://github.com/expressjs/session/assets/94886510/65ae2501-cb2a-4313-80d9-8a56da5e3572">

I am aware that there may be some security concerns related to my changes (Like if there are any other Reverse Proxys running locally under production mode, cookie will still be set even though they haven't set 'x-forwarded-proto' headers). If possible, could you happen to identify these issues so I can learn from them? Thank you! :)