### PR TITLE
docs: update var keyword to const

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install express-session
 ## API
 
 ```js
-var session = require('express-session')
+const session = require('express-session')
 ```
 
 ### session(options)
@@ -158,7 +158,7 @@ have your node.js behind a proxy and are using `secure: true`, you need to set
 "trust proxy" in express:
 
 ```js
-var app = express()
+const app = express()
 app.set('trust proxy', 1) // trust first proxy
 app.use(session({
   secret: 'keyboard cat',
@@ -172,8 +172,8 @@ For using secure cookies in production, but allowing for testing in development,
 the following is an example of enabling this setup based on `NODE_ENV` in express:
 
 ```js
-var app = express()
-var sess = {
+const app = express()
+const sess = {
   secret: 'keyboard cat',
   cookie: {}
 }
@@ -445,7 +445,7 @@ to adjust the `.expires` property appropriately. The following
 are essentially equivalent
 
 ```js
-var hour = 3600000
+const hour = 3600000
 req.session.cookie.expires = new Date(Date.now() + hour)
 req.session.cookie.maxAge = hour
 ```
@@ -881,11 +881,11 @@ based session store. Supports all backends supported by Fortune (MongoDB, Redis,
 A simple example using `express-session` to store page views for a user.
 
 ```js
-var express = require('express')
-var parseurl = require('parseurl')
-var session = require('express-session')
+const express = require('express')
+const parseurl = require('parseurl')
+const session = require('express-session')
 
-var app = express()
+const app = express()
 
 app.use(session({
   secret: 'keyboard cat',
@@ -899,7 +899,7 @@ app.use(function (req, res, next) {
   }
 
   // get the url pathname
-  var pathname = parseurl(req).pathname
+  const pathname = parseurl(req).pathname
 
   // count the views
   req.session.views[pathname] = (req.session.views[pathname] || 0) + 1
@@ -923,11 +923,11 @@ app.listen(3000)
 A simple example using `express-session` to keep a user log in session.
 
 ```js
-var escapeHtml = require('escape-html')
-var express = require('express')
-var session = require('express-session')
+const escapeHtml = require('escape-html')
+const express = require('express')
+const session = require('express-session')
 
-var app = express()
+const app = express()
 
 app.use(session({
   secret: 'keyboard cat',


### PR DESCRIPTION
Closes issue: #993

Updated the usage of `var` keyword to `const` since `var` keyword is considered outdated in modern JavaScript development.