### PR TITLE
deps: migrate from tilde to caret

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,3 @@
-unreleased
-==================
-
-  * deps: depd@^2.0.0, on-headers@^1.0.0, parseurl@^1.3.3, uid-safe@^2.1.5
-    - Change tilde (~) to caret (^) policy: https://github.com/expressjs/discussions/pull/290
-
 1.18.1 / 2024-10-08
 ==========
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+unreleased
+==================
+
+  * deps: depd@^2.0.0, on-headers@^1.0.0, parseurl@^1.3.3, uid-safe@^2.1.5
+    - Change tilde (~) to caret (^) policy: https://github.com/expressjs/discussions/pull/290
+
 1.18.1 / 2024-10-08
 ==========
 

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "cookie": "0.7.2",
     "cookie-signature": "1.0.7",
     "debug": "2.6.9",
-    "depd": "~2.0.0",
-    "on-headers": "~1.0.2",
-    "parseurl": "~1.3.3",
+    "depd": "^2.0.0",
+    "on-headers": "^1.0.2",
+    "parseurl": "^1.3.3",
     "safe-buffer": "5.2.1",
-    "uid-safe": "~2.1.5"
+    "uid-safe": "^2.1.5"
   },
   "devDependencies": {
     "after": "0.8.2",


### PR DESCRIPTION
Updated as part of this: https://github.com/expressjs/discussions/pull/290

deps: depd@^2.0.0, on-headers@^1.0.0, parseurl@^1.3.3, uid-safe@^2.1.5