### PR TITLE
fix(buffer): use node:buffer instead of safe-buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
  * @private
  */
 
-var Buffer = require('safe-buffer').Buffer
+var Buffer = require('node:buffer').Buffer
 var cookie = require('cookie');
 var crypto = require('crypto')
 var debug = require('debug')('express-session');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "depd": "~2.0.0",
     "on-headers": "~1.0.2",
     "parseurl": "~1.3.3",
-    "safe-buffer": "5.2.1",
     "uid-safe": "~2.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Since express@5 will support a minimum of nodejs version 18, I think it would be safe to use `node:buffer`

Cc @wesleytodd @UlisesGascon 