### PR TITLE
refactor: remove unused `sess` parameter from `generateSessionId` fun…

### DIFF
--- a/index.js
+++ b/index.js
@@ -523,7 +523,7 @@ function session(options) {
  * @private
  */
 
-function generateSessionId(sess) {
+function generateSessionId() {
   return uid(24);
 }
 


### PR DESCRIPTION
…ction

The `sess` parameter was not used in `generateSessionId`, so it was removed to improve code clarity and reduce potential confusion.