### PR TITLE
Add express-sqlite3 session store to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ a [variety of storage types](https://www.npmjs.com/package/cache-manager#store-e
 [express-sessions-url]: https://www.npmjs.com/package/express-sessions
 [express-sessions-image]: https://badgen.net/github/stars/konteck/express-sessions?label=%E2%98%85
 
-[![★][express-sqlite3-image] express-sqlite3][express-sqlite3-url] A [SQLite3](https://github.com/mapbox/node-sqlite3) based session store.
+[![★][express-sqlite3-image] express-sqlite3][express-sqlite3-url] A light-weight and configurable [SQLite3](https://github.com/mapbox/node-sqlite3) based session store.
 
 [express-sqlite3-url]: https://www.npmjs.com/package/express-sqlite3
 [express-sqlite3-image]: https://badgen.net/github/stars/RomanBurunkov/express-sqlite3?label=%E2%98%85

--- a/README.md
+++ b/README.md
@@ -783,6 +783,11 @@ a [variety of storage types](https://www.npmjs.com/package/cache-manager#store-e
 [express-sessions-url]: https://www.npmjs.com/package/express-sessions
 [express-sessions-image]: https://badgen.net/github/stars/konteck/express-sessions?label=%E2%98%85
 
+[![★][express-sqlite3-image] express-sqlite3][express-sqlite3-url] A [SQLite3](https://github.com/mapbox/node-sqlite3) based session store.
+
+[express-sqlite3-url]: https://www.npmjs.com/package/express-sqlite3
+[express-sqlite3-image]: https://badgen.net/github/stars/RomanBurunkov/express-sqlite3?label=%E2%98%85
+
 [![★][firestore-store-image] firestore-store][firestore-store-url] A [Firestore](https://github.com/hendrysadrak/firestore-store)-based session store.
 
 [firestore-store-url]: https://www.npmjs.com/package/firestore-store


### PR DESCRIPTION
Hi, would like to add express-sqlite3 session store to the list of compatible session stores.

express-sqlite3 is a fully tested light-weight and configurable SQlite3 sessions store which uses latest version of SQlite3.
Created to be fully compatible with express-session.
