### PR TITLE
lint: upgrade linting environment to ECMAScript 2022

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,10 +6,14 @@ plugins:
 overrides:
   - files: '**/*.md'
     processor: 'markdown/markdown'
+env:
+  es2022: true
+  node: true
 rules:
   eol-last: error
   eqeqeq: ["error", "always", { "null": "ignore" }]
   indent: ["error", 2, { "MemberExpression": "off", "SwitchCase": 1 }]
   no-mixed-spaces-and-tabs: error
   no-trailing-spaces: error
+  no-unused-vars: [error, { vars: all, args: none, ignoreRestSiblings: true }]
   one-var: ["error", { "initialized": "never" }]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ $ npm install express-session
 ## API
 
 ```js
-var session = require('express-session')
+const session = require('express-session')
+
+const app = express()
+app.use(session(/* options */))
 ```
 
 ### session(options)


### PR DESCRIPTION
This PR updates the eslint JavaScript linting environment to the 2022 standard. This is based on the wanted Node 18 support and aligns with data in [node.green](https://node.green/) and what is used in the main express repo currently, see [expessjs/express/.eslintrc.yml](https://github.com/expressjs/express/blob/82fc12a40b3e6694e9a2c9b1376e7548d95779f6/.eslintrc.yml).

In addition to setting the ES version, we set `node` environment. It's not needed, I think, but makes the file match more with the main repo. The documentation for that says "Node.js global variables and Node.js scoping".

See comments below about added rule and the rule we have, which doesn't exists in the main repo.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
