### PR TITLE
feat: update default value of resave option to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,7 @@ parallel requests to your server and changes made to the session in one
 request may get overwritten when the other request ends, even if it made no
 changes (this behavior also depends on what store you're using).
 
-The default value is `true`, but using the default has been deprecated,
-as the default will change in the future. Please research into this setting
+The default value is `false`. Please research into this setting
 and choose what is appropriate to your use-case. Typically, you'll want
 `false`.
 

--- a/index.js
+++ b/index.js
@@ -108,8 +108,7 @@ function session(options) {
   }
 
   if (resaveSession === undefined) {
-    deprecate('undefined resave option; provide resave option');
-    resaveSession = true;
+    resaveSession = false;
   }
 
   if (saveUninitializedSession === undefined) {

--- a/test/session.js
+++ b/test/session.js
@@ -936,7 +936,7 @@ describe('session()', function(){
   });
 
   describe('resave option', function(){
-    it('should default to true', function(done){
+    it('should default to false', function(done){
       var store = new session.MemoryStore()
       var server = createServer({ store: store }, function (req, res) {
         req.session.user = 'bob'
@@ -946,14 +946,15 @@ describe('session()', function(){
       request(server)
       .get('/')
       .expect(shouldSetSessionInStore(store))
-      .expect(200, function(err, res){
-        if (err) return done(err);
+      .expect(200, function (err, res) {
+        if (err) return done(err)
+
         request(server)
-        .get('/')
-        .set('Cookie', cookie(res))
-        .expect(shouldSetSessionInStore(store))
-        .expect(200, done);
-      });
+          .get('/')
+          .set('Cookie', cookie(res))
+          .expect(shouldNotSetSessionInStore(store))
+          .expect(200, done)
+      })
     });
 
     describe('when true', function () {


### PR DESCRIPTION
I think it's better to set it to false instead of making this field required.

@UlisesGascon @raphendyr WDYT?