### PR TITLE
refactor: replace uid-safe with native implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+  * Replace `uid-safe` with `crypto.randomUUID()` for session ID generation
+    - Session IDs are now UUID v4 strings instead of 32-character base64url strings
+    - Use the `genid` option to provide a custom generator if you need to keep the previous format,
+      e.g. `genid: function () { return crypto.randomBytes(24).toString('base64url') }`
+
 1.18.1 / 2024-10-08
 ==========
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 unreleased
 ==========
 
+## ⚠️ BREAKING CHANGES
+
   * Replace `uid-safe` with `crypto.randomUUID()` for session ID generation
     - Session IDs are now UUID v4 strings instead of 32-character base64url strings
     - Use the `genid` option to provide a custom generator if you need to keep the previous format,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,8 @@
 unreleased
 ==========
 
-## ⚠️ BREAKING CHANGES
-
-  * Replace `uid-safe` with `crypto.randomUUID()` for session ID generation
-    - Session IDs are now UUID v4 strings instead of 32-character base64url strings
-    - Use the `genid` option to provide a custom generator if you need to keep the previous format,
-      e.g. `genid: function () { return crypto.randomBytes(24).toString('base64url') }`
+  * Replace `uid-safe` dependency with built-in `crypto.randomBytes` for session ID generation
+    - Session IDs keep the same format as before (32-character base64url strings)
 
 1.18.1 / 2024-10-08
 ==========

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ var deprecate = require('depd')('express-session');
 var onHeaders = require('on-headers')
 var parseUrl = require('parseurl');
 var signature = require('cookie-signature')
-var uid = require('uid-safe').sync
 
 var Cookie = require('./session/cookie')
 var MemoryStore = require('./session/memory')
@@ -504,7 +503,7 @@ function session(options) {
  */
 
 function generateSessionId(sess) {
-  return uid(24);
+  return crypto.randomUUID();
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -502,8 +502,8 @@ function session(options) {
  * @private
  */
 
-function generateSessionId(sess) {
-  return crypto.randomUUID();
+function generateSessionId() {
+  return crypto.randomBytes(24).toString('base64url');
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "debug": "4.4.3",
     "depd": "~2.0.0",
     "on-headers": "~1.0.2",
-    "parseurl": "~1.3.3",
-    "uid-safe": "~2.1.5"
+    "parseurl": "~1.3.3"
   },
   "devDependencies": {
     "after": "0.8.2",


### PR DESCRIPTION
uid-safe can be replace by simple native function to generate safe uids.

uid-safe uses random-bytes which in turns uses crypto.randomBytes. So this should be save in terms of NodeJs compatibility and generate the same random uids.

Edit: I gave the repo another look and this should probably target the v2 branch? I can migrate the change over if this is change is generally desirable. 


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
