### PR TITLE
chore: use node:buffer instead of safe-buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
  * @private
  */
 
-var Buffer = require('safe-buffer').Buffer
+var Buffer = require("node:buffer").Buffer;
 var cookie = require('cookie');
 var crypto = require('crypto')
 var debug = require('debug')('express-session');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "depd": "~2.0.0",
     "on-headers": "~1.1.0",
     "parseurl": "~1.3.3",
-    "safe-buffer": "5.2.1",
     "uid-safe": "~2.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
use node:buffer instead of safe-buffer

Same change was done and shipped in express already a while ago 
https://github.com/expressjs/express/commit/c70197ad33057e88565bd7bde6454f9225ead6cc

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
