### PR TITLE
feat: add preventTouch option to Session.save method

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ req.session.reload(function(err) {
 })
 ```
 
-#### Session.save(callback)
+#### Session.save([preventTouch, callback])
 
 Save the session back to the store, replacing the contents on the store with the
 contents in memory (though a store may do something else--consult the store's
@@ -412,9 +412,26 @@ does not need to be called.
 There are some cases where it is useful to call this method, for example,
 redirects, long-lived requests or in WebSockets.
 
+If `preventTouch` is `true`, `store.touch` will not be called at the end of the
+HTTP response, which can be useful if using this library with something like 
+[Next.js getServerSideProps](https://github.com/expressjs/session/issues/870) to prevent [gssp-no-mutating-res](https://nextjs.org/docs/messages/gssp-no-mutating-res).
+
+**Note** `rolling: true` may still cause the above error.
+
 ```js
 req.session.save(function(err) {
   // session saved
+})
+```
+
+```js
+// session saved + store.touch will not be called
+req.session.save(true)
+```
+
+```js
+req.session.save(true, function(err) {
+  // session saved + store.touch will not be called
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -213,6 +213,7 @@ function session(options) {
     var originalId;
     var savedHash;
     var touched = false
+    var preventTouchForReq = false
 
     // expose store
     req.sessionStore = store;
@@ -408,10 +409,23 @@ function session(options) {
         _reload.call(this, rewrapmethods(this, callback))
       }
 
-      function save() {
-        debug('saving %s', this.id);
-        savedHash = hash(this);
-        _save.apply(this, arguments);
+      function save(preventTouchOrCb, cb) {
+        debug('saving %s', this.id)
+        savedHash = hash(this)
+
+        var _cb = cb;
+
+        if (typeof preventTouchOrCb === 'function') {
+          _cb = preventTouchOrCb
+          preventTouchOrCb = false
+        }
+
+        if (preventTouchOrCb === true) {
+          preventTouchForReq = true
+          debug('touch disabled for this request via save(preventTouch=true)')
+        }
+
+        _save.call(this, _cb)
       }
 
       Object.defineProperty(sess, 'reload', {
@@ -465,7 +479,7 @@ function session(options) {
         return false;
       }
 
-      return cookieId === req.sessionID && !shouldSave(req);
+      return !preventTouchForReq && cookieId === req.sessionID && !shouldSave(req);
     }
 
     // determine if cookie should be set on response


### PR DESCRIPTION
Fixes #870 by adding an optional `preventTouch` parameter to `Session.save` which will prevent `store.touch` from being called, `res` from being accessed, and Next.js from complaining.

Fully backwards compatible, and tests pass.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
