### PR TITLE
deps: use tilde notation for dependencies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# Unreleased changes
+
+### 🚀 Improvements
+
+* deps: use tilde notation for dependencies
+
 1.18.2 / 2025-07-17
 ==========
   * deps: mocha@10.8.2

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "cookie": "0.7.2",
-    "cookie-signature": "1.0.7",
-    "debug": "2.6.9",
+    "cookie": "~0.7.2",
+    "cookie-signature": "~1.0.7",
+    "debug": "~2.6.9",
     "depd": "~2.0.0",
     "on-headers": "~1.1.0",
     "parseurl": "~1.3.3",
-    "safe-buffer": "5.2.1",
+    "safe-buffer": "~5.2.1",
     "uid-safe": "~2.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
As is already being done in other packages, use tilde notation for dependencies.