### PR TITLE
chore: remove history.md from being packaged on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "files": [
     "session/",
-    "HISTORY.md",
     "index.js"
   ],
   "engines": {


### PR DESCRIPTION
We don’t need to upload these file to npm, it reduces the package size, especially for servers that have limited disk space

## Before

package size: 23.2 kB
unpacked size: 87.2 kB

## After

package size: 19.7 kB
unpacked size: 75.5 kB
