### PR TITLE
fix: refresh cookie options for rolling sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,18 +158,24 @@ function session(options) {
   store.generate = function(req){
     req.sessionID = generateId(req);
     req.session = new Session(req);
-    req.session.cookie = new Cookie(typeof cookieOptions === 'function' ? cookieOptions(req) : cookieOptions);
+    req.session.cookie = createCookie(req);
+  };
 
+  function createCookie(req) {
+    var options = typeof cookieOptions === 'function' ? cookieOptions(req) : cookieOptions
+    var sessionCookie = new Cookie(options);
     var isSecure = issecure(req, trustProxy);
 
-    if (cookieOptions.secure === 'auto') {
-      req.session.cookie.secure = isSecure;
+    if (options.secure === 'auto') {
+      sessionCookie.secure = isSecure;
     }
 
-    if (cookieOptions.sameSite === 'auto') {
-      req.session.cookie.sameSite = isSecure ? 'none' : 'lax';
+    if (options.sameSite === 'auto') {
+      sessionCookie.sameSite = isSecure ? 'none' : 'lax';
     }
-  };
+
+    return sessionCookie
+  }
 
   var storeImplementsTouch = typeof store.touch === 'function';
 
@@ -385,6 +391,11 @@ function session(options) {
     // inflate the session
     function inflate (req, sess) {
       store.createSession(req, sess)
+
+      if (rollingSessions) {
+        req.session.cookie = createCookie(req)
+      }
+
       originalId = req.sessionID
       originalHash = hash(sess)
 

--- a/test/session.js
+++ b/test/session.js
@@ -1133,6 +1133,38 @@ describe('session()', function(){
       });
     });
 
+    it('should apply current cookie options on existing session', function (done) {
+      var store = new session.MemoryStore()
+      var server = createServer({
+        cookie: { maxAge: 1000, sameSite: 'none' },
+        rolling: true,
+        store: store
+      }, function (req, res) {
+        req.session.user = 'bob'
+        res.end()
+      })
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function (err, res) {
+        if (err) return done(err)
+
+        var updatedServer = createServer({
+          cookie: { maxAge: 2000, sameSite: 'strict' },
+          rolling: true,
+          store: store
+        })
+
+        request(updatedServer)
+        .get('/')
+        .set('Cookie', cookie(res))
+        .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'SameSite', 'Strict'))
+        .expect(shouldSetCookieToExpireIn('connect.sid', 2000))
+        .expect(200, done)
+      })
+    })
+
     it('should not force cookie on uninitialized session if saveUninitialized option is set to false', function(done){
       var store = new session.MemoryStore()
       var server = createServer({ store: store, rolling: true, saveUninitialized: false })


### PR DESCRIPTION
## Summary

Refresh cookie options from the current middleware configuration when an existing session is loaded with `rolling: true`.

This keeps rolled `Set-Cookie` headers in sync after deployments that change cookie settings such as `sameSite` or `maxAge`, while preserving the existing session id and store entry.

Fixes #1077.

## Validation

- `npx mocha --require test/support/env --check-leaks --no-exit --reporter spec --grep "rolling option" test/session.js`
- `npx eslint index.js test/session.js`
- `bash -lc "tr -d '\r' < test/support/gencert.sh | bash"`
- `npx mocha --require test/support/env --check-leaks --no-exit --reporter spec test/`
- `npm run lint`
- `git diff --check`

`npm test` itself cannot be launched from this Windows shell because the npm script starts with `./test/support/gencert.sh`, which `cmd` rejects as `'.' is not recognized`. I ran the certificate script through bash after stripping checkout CRLFs, then ran the full mocha suite directly.