### PR TITLE
Fix session cookie refresh when cookie options are mutated

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,8 @@ function session(options) {
     if (cookieOptions.sameSite === 'auto') {
       req.session.cookie.sameSite = isSecure ? 'none' : 'lax';
     }
+
+    req.session.cookie._isModified = false;
   };
 
   var storeImplementsTouch = typeof store.touch === 'function';
@@ -246,7 +248,7 @@ function session(options) {
 
       if (!touched) {
         // touch session
-        req.session.touch()
+        req.session.resetMaxAge(false)
         touched = true
       }
 
@@ -342,7 +344,7 @@ function session(options) {
 
       if (!touched) {
         // touch session
-        req.session.touch()
+        req.session.resetMaxAge(false)
         touched = true
       }
 
@@ -484,7 +486,7 @@ function session(options) {
 
       return cookieId !== req.sessionID
         ? saveUninitializedSession || isModified(req.session)
-        : rollingSessions || req.session.cookie.expires != null && isModified(req.session);
+        : rollingSessions || req.session.cookie.expires != null && (req.session.cookie._isModified || isModified(req.session));
     }
 
     // generate a session if the browser doesn't send a sessionID

--- a/session/cookie.js
+++ b/session/cookie.js
@@ -26,6 +26,7 @@ var Cookie = module.exports = function Cookie(options) {
   this.path = '/';
   this.maxAge = null;
   this.httpOnly = true;
+  this._isModified = false;
 
   if (options) {
     if (typeof options !== 'object') {
@@ -42,6 +43,8 @@ var Cookie = module.exports = function Cookie(options) {
   if (this.originalMaxAge === undefined || this.originalMaxAge === null) {
     this.originalMaxAge = this.maxAge
   }
+
+  this._isModified = false;
 };
 
 /*!
@@ -58,6 +61,7 @@ Cookie.prototype = {
    */
 
   set expires(date) {
+    this._isModified = true;
     this._expires = date;
     this.originalMaxAge = this.maxAge;
   },

--- a/session/session.js
+++ b/session/session.js
@@ -55,8 +55,15 @@ defineMethod(Session.prototype, 'touch', function touch() {
  * @api public
  */
 
-defineMethod(Session.prototype, 'resetMaxAge', function resetMaxAge() {
+defineMethod(Session.prototype, 'resetMaxAge', function resetMaxAge(touched) {
+  var changed = this.cookie._isModified;
+
+  if (touched !== false) {
+    changed = true;
+  }
+
   this.cookie.maxAge = this.cookie.originalMaxAge;
+  this.cookie._isModified = changed;
   return this;
 });
 

--- a/session/store.js
+++ b/session/store.js
@@ -96,6 +96,7 @@ Store.prototype.createSession = function(req, sess){
 
   // keep originalMaxAge intact
   sess.cookie.originalMaxAge = originalMaxAge
+  sess.cookie._isModified = false
 
   req.session = new Session(req, sess);
   return req.session;

--- a/test/session.js
+++ b/test/session.js
@@ -2015,6 +2015,36 @@ describe('session()', function(){
         })
       })
 
+      it('should set cookie when only cookie is modified', function (done) {
+        var store = new session.MemoryStore()
+        var server = createServer({ store: store, resave: false }, function (req, res) {
+          if (!req.session.hit) {
+            req.session.hit = true
+            return res.end('created')
+          }
+
+          req.session.cookie.maxAge = 300000
+          req.session.touch()
+          req.session.save(function (err) {
+            if (err) return res.end(err.message)
+            res.end('saved')
+          })
+        })
+
+        request(server)
+          .get('/')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, 'created', function (err, res) {
+            if (err) return done(err)
+
+            request(server)
+              .get('/')
+              .set('Cookie', cookie(res))
+              .expect(shouldSetCookie('connect.sid'))
+              .expect(200, 'saved', done)
+          })
+      })
+
       it('should prevent end-of-request save on reloaded session', function (done) {
         var store = new session.MemoryStore()
         var server = createServer({ store: store }, function (req, res) {


### PR DESCRIPTION
## Summary
- Track explicit session cookie mutations so cookie-only updates can emit `Set-Cookie` for existing sessions.
- Preserve the clean cookie state when sessions are created or loaded from the store, so unmodified sessions keep the existing non-rolling behavior.
- Add regression coverage for `req.session.cookie.maxAge` changes followed by `touch()` and `save()`.

Fixes #1002.

## Validation
- `npx eslint index.js session/cookie.js session/session.js session/store.js test/session.js`
- `bash -lc "tr -d '\r' < test/support/gencert.sh | bash"`
- `npx mocha --require test/support/env --check-leaks --no-exit --reporter spec test/session.js` (143 passing)