### PR TITLE
fix: refresh cookie options for rolling sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,18 +158,24 @@ function session(options) {
   store.generate = function(req){
     req.sessionID = generateId(req);
     req.session = new Session(req);
-    req.session.cookie = new Cookie(typeof cookieOptions === 'function' ? cookieOptions(req) : cookieOptions);
+    req.session.cookie = createCookie(req);
+  };
 
+  function createCookie(req) {
+    var options = typeof cookieOptions === 'function' ? cookieOptions(req) : cookieOptions
+    var sessionCookie = new Cookie(options);
     var isSecure = issecure(req, trustProxy);
 
-    if (cookieOptions.secure === 'auto') {
-      req.session.cookie.secure = isSecure;
+    if (options.secure === 'auto') {
+      sessionCookie.secure = isSecure;
     }
 
-    if (cookieOptions.sameSite === 'auto') {
-      req.session.cookie.sameSite = isSecure ? 'none' : 'lax';
+    if (options.sameSite === 'auto') {
+      sessionCookie.sameSite = isSecure ? 'none' : 'lax';
     }
-  };
+
+    return sessionCookie
+  }
 
   var storeImplementsTouch = typeof store.touch === 'function';
 
@@ -385,6 +391,11 @@ function session(options) {
     // inflate the session
     function inflate (req, sess) {
       store.createSession(req, sess)
+
+      if (rollingSessions) {
+        req.session.cookie = createCookie(req)
+      }
+
       originalId = req.sessionID
       originalHash = hash(sess)
 

--- a/test/session.js
+++ b/test/session.js
@@ -1133,6 +1133,38 @@ describe('session()', function(){
       });
     });
 
+    it('should apply current cookie options on existing session', function (done) {
+      var store = new session.MemoryStore()
+      var server = createServer({
+        cookie: { maxAge: 1000, sameSite: 'none' },
+        rolling: true,
+        store: store
+      }, function (req, res) {
+        req.session.user = 'bob'
+        res.end()
+      })
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function (err, res) {
+        if (err) return done(err)
+
+        var updatedServer = createServer({
+          cookie: { maxAge: 2000, sameSite: 'strict' },
+          rolling: true,
+          store: store
+        })
+
+        request(updatedServer)
+        .get('/')
+        .set('Cookie', cookie(res))
+        .expect(shouldSetCookieWithAttributeAndValue('connect.sid', 'SameSite', 'Strict'))
+        .expect(shouldSetCookieToExpireIn('connect.sid', 2000))
+        .expect(200, done)
+      })
+    })
+
     it('should not force cookie on uninitialized session if saveUninitialized option is set to false', function(done){
       var store = new session.MemoryStore()
       var server = createServer({ store: store, rolling: true, saveUninitialized: false })


### PR DESCRIPTION
## Changes

- Ensure cookie options are re-applied for each request when `rolling: true`, so updated config is reflected for existing sessions.
- Extracted cookie creation into a shared helper for consistency between new and existing sessions.
- Added regression test for an existing session receiving updated cookie attributes/expiry on rolling requests.

## Validation

- node node_modules/mocha/bin/mocha --require test/support/env --check-leaks --no-exit --reporter spec --grep "rolling option" test/session.js
- node node_modules/mocha/bin/mocha --require test/support/env --check-leaks --no-exit --reporter spec test/session.js
- node node_modules/eslint/bin/eslint.js index.js test/session.js
