### PR TITLE
deps: debug@4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "cookie": "0.7.2",
     "cookie-signature": "1.0.7",
-    "debug": "2.6.9",
+    "debug": "4.4.3",
     "depd": "~2.0.0",
     "on-headers": "~1.0.2",
     "parseurl": "~1.3.3",


### PR DESCRIPTION
Bumps `debug` to 4.4.3 for the v2 branch, where the package already requires Node.js `>=18`.

Supersedes #1014, which is unmergeable on `master` because of the v1 minimum Node.js version.

Tests:
- `npm run lint`
- `npm test`