### PR TITLE
deps: cookie@1.1.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -521,7 +521,7 @@ function getcookie(req, name, secrets) {
 
   // read from cookie header
   if (header) {
-    var cookies = cookie.parse(header);
+    var cookies = cookie.parseCookie(header);
 
     raw = cookies[name];
 
@@ -611,7 +611,7 @@ function issecure(req, trustProxy) {
 
 function setcookie(res, name, val, secret, options) {
   var signed = 's:' + signature.sign(val, secret);
-  var data = cookie.serialize(name, signed, options);
+  var data = cookie.stringifySetCookie(name, signed, options);
 
   debug('set-cookie %s', data);
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "expressjs/session",
   "license": "MIT",
   "dependencies": {
-    "cookie": "0.7.2",
+    "cookie": "1.1.1",
     "cookie-signature": "1.0.7",
     "debug": "2.6.9",
     "depd": "~2.0.0",

--- a/session/cookie.js
+++ b/session/cookie.js
@@ -136,7 +136,7 @@ Cookie.prototype = {
    */
 
   serialize: function(name, val){
-    return cookie.serialize(name, val, this.data);
+    return cookie.stringifySetCookie(name, val, this.data);
   },
 
   /**

--- a/test/session.js
+++ b/test/session.js
@@ -1944,7 +1944,7 @@ describe('session()', function(){
 
           server.on('error', function onerror (err) {
             assert.ok(err)
-            assert.strictEqual(err.message, 'option expires is invalid')
+            assert.strictEqual(err.message, 'option expires is invalid: Invalid Date')
             cb()
           })
 
@@ -1955,8 +1955,8 @@ describe('session()', function(){
 
         it('should preserve cookies set before writeHead is called', function(done){
           var server = createServer(null, function (req, res) {
-            var cookie = new Cookie()
-            res.setHeader('Set-Cookie', cookie.serialize('previous', 'cookieValue'))
+            var sessionCookie = new Cookie()
+            res.setHeader('Set-Cookie', sessionCookie.serialize('previous', 'cookieValue'))
             res.end()
           })
 
@@ -1968,9 +1968,9 @@ describe('session()', function(){
 
         it('should preserve cookies set in writeHead', function (done) {
           var server = createServer(null, function (req, res) {
-            var cookie = new Cookie()
+            var sessionCookie = new Cookie()
             res.writeHead(200, {
-              'Set-Cookie': cookie.serialize('previous', 'cookieValue')
+              'Set-Cookie': sessionCookie.serialize('previous', 'cookieValue')
             })
             res.end()
           })


### PR DESCRIPTION
Bumps `cookie` to 1.1.1 for the v2 branch, where the package already requires Node.js `>=18`.

This also updates express-session to use `cookie@1`'s current `parseCookie` and `stringifySetCookie` APIs instead of the deprecated `parse` and `serialize` aliases, and adjusts the invalid `expires` test expectation to match the more specific error message. This chase was not strictly necessary but reduces friction should we ever update `cookie` to v2.

Tests:
- `npm run lint`
- `npm test`