### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,9 @@
     "test-ci": "nyc --reporter=lcov --reporter=text npm test",
     "test-cov": "nyc npm test",
     "version": "node scripts/version-history.js && git add HISTORY.md"
+  },
+  "homepage": "https://github.com/expressjs/session",
+  "bugs": {
+    "url": "https://github.com/expressjs/session/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "test-cov": "nyc npm test",
     "version": "node scripts/version-history.js && git add HISTORY.md"
   },
-  "homepage": "https://github.com/expressjs/session",
+  "homepage": "https://github.com/koajs/session",
   "bugs": {
-    "url": "https://github.com/expressjs/session/issues"
+    "url": "https://github.com/koajs/session/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.