### PR TITLE
fix: avoid duplicate save after regenerate

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,7 @@ function session(options) {
     var originalHash;
     var originalId;
     var savedHash;
+    var savedId;
     var touched = false
 
     // expose store
@@ -383,6 +384,8 @@ function session(options) {
       store.generate(req);
       originalId = req.sessionID;
       originalHash = hash(req.session);
+      savedHash = undefined
+      savedId = undefined
       wrapmethods(req.session);
     }
 
@@ -394,6 +397,10 @@ function session(options) {
 
       if (!resaveSession) {
         savedHash = originalHash
+        savedId = req.sessionID
+      } else {
+        savedHash = undefined
+        savedId = undefined
       }
 
       wrapmethods(req.session)
@@ -411,8 +418,19 @@ function session(options) {
 
     // wrap session methods
     function wrapmethods(sess) {
+      var _regenerate = sess.regenerate
       var _reload = sess.reload
       var _save = sess.save;
+
+      function regenerate(callback) {
+        debug('regenerating %s', this.id)
+        var sess = this
+        _regenerate.call(this, function () {
+          savedHash = undefined
+          savedId = undefined
+          rewrapmethods(sess, callback).apply(this, arguments)
+        })
+      }
 
       function reload(callback) {
         debug('reloading %s', this.id)
@@ -422,8 +440,16 @@ function session(options) {
       function save() {
         debug('saving %s', this.id);
         savedHash = hash(this);
+        savedId = this.id;
         _save.apply(this, arguments);
       }
+
+      Object.defineProperty(sess, 'regenerate', {
+        configurable: true,
+        enumerable: false,
+        value: regenerate,
+        writable: true
+      })
 
       Object.defineProperty(sess, 'reload', {
         configurable: true,
@@ -447,7 +473,7 @@ function session(options) {
 
     // check if session has been saved
     function isSaved(sess) {
-      return originalId === sess.id && savedHash === hash(sess);
+      return savedId === sess.id && savedHash === hash(sess);
     }
 
     // determine if session should be destroyed

--- a/test/session.js
+++ b/test/session.js
@@ -1918,6 +1918,70 @@ describe('session()', function(){
           .expect(200, 'false', done)
         });
       })
+
+      it('should prevent end-of-request save after manual save', function (done) {
+        var store = new session.MemoryStore()
+        var count = 0
+        var _set = store.set
+        var server = createServer({ store: store, resave: false, saveUninitialized: false }, function (req, res) {
+          req.session.regenerate(function (err) {
+            if (err) return res.end(err.message)
+            req.session.value = 'foo'
+            req.session.save(function (err) {
+              if (err) return res.end(err.message)
+              res.end('saved')
+            })
+          })
+        })
+
+        store.set = function set () {
+          count++
+          return _set.apply(this, arguments)
+        }
+
+        request(server)
+          .get('/')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, 'saved', function (err) {
+            if (err) return done(err)
+            assert.strictEqual(count, 1)
+            done()
+          })
+      })
+
+      it('should set cookie after manual save without data changes', function (done) {
+        var store = new session.MemoryStore()
+        var count = 0
+        var _set = store.set
+        var server = createServer({ store: store, resave: false, saveUninitialized: false }, function (req, res) {
+          var oldId = req.session.id
+
+          req.session.regenerate(function (err) {
+            if (err) return res.end(err.message)
+            req.session.save(function (err) {
+              if (err) return res.end(err.message)
+              res.end(oldId + ':' + req.session.id)
+            })
+          })
+        })
+
+        store.set = function set () {
+          count++
+          return _set.apply(this, arguments)
+        }
+
+        request(server)
+          .get('/')
+          .expect(shouldSetCookie('connect.sid'))
+          .expect(200, function (err, res) {
+            if (err) return done(err)
+            var ids = res.text.split(':')
+            assert.strictEqual(sid(res), ids[1])
+            assert.notStrictEqual(sid(res), ids[0])
+            assert.strictEqual(count, 1)
+            done()
+          })
+      })
     })
 
     describe('.reload()', function () {


### PR DESCRIPTION
Fixes #935

## Reproduction
On current `master`, a request that calls `req.session.regenerate()`, mutates the new session, and then calls `req.session.save()` writes the same regenerated session twice. A minimal supertest reproduction counted `MemoryStore#set` calls and showed `total saves after response: 2`.

## Root cause
`regenerate()` replaces `req.session` with a new `Session`, but the middleware only wrapped the original session's methods. As a result, a manual `save()` on the regenerated session did not update the request's saved-session tracking hash, so the response finalizer treated it as unsaved and wrote it again.

## Fix
Wrap `regenerate()` like `reload()` so the replacement session gets the middleware method wrappers. Track the explicitly saved session id in a separate `savedId` closure variable alongside `savedHash`, and use that pair only for `isSaved()`.

Cookie-setting and modification semantics are unchanged: `originalId` is not mutated by `save()`, so session id rotation still makes `isModified()` true and still emits `Set-Cookie` for the new id even when the regenerated session has no data changes.

## Compatibility / security notes
This is a conservative behavior fix: explicit session regeneration and saving still persists and sends the new session cookie, but avoids an extra store write that could overwrite concurrent updates. No dependencies or public API are changed.

## Validation
- Original regression test fails without the fix: `0 passing, 1 failing`, with `2 !== 1` store writes.
- Added no-data-change regression test fails under the first version of this fix: `0 passing, 1 failing`, missing the expected `Set-Cookie` header.
- Targeted regenerate/save tests pass with this rework: `2 passing`.
- Full suite via Git Bash on Windows: `175 passing (3s)`.
- `npm run lint`: passed.
- Direct `npm test` on Windows fails before running tests because npm/cmd cannot execute `./test/support/gencert.sh` (`'.' is not recognized...`); reran the same script/test command through Git Bash with `MSYS_NO_PATHCONV=1` successfully.